### PR TITLE
fix: github permission for synchronizer

### DIFF
--- a/pkg/github/synchronizer.go
+++ b/pkg/github/synchronizer.go
@@ -143,7 +143,7 @@ func listPendingTeamInvitations(ctx context.Context, c *github.Client, orgID, te
 func (s *Synchronizer) accessToken(ctx context.Context) (string, error) {
 	tr := &githubauth.TokenRequestAllRepos{
 		Permissions: map[string]string{
-			"organization": "write",
+			"members": "write",
 		},
 	}
 


### PR DESCRIPTION
Tested, should be members. also see [members](https://docs.github.com/en/rest/authentication/permissions-required-for-github-apps?apiVersion=2022-11-28#organization-permissions-for-members)