### PR TITLE
fix: when invitation missing login but has email info

### DIFF
--- a/pkg/github/synchronizer.go
+++ b/pkg/github/synchronizer.go
@@ -84,7 +84,7 @@ func (s *Synchronizer) Sync(ctx context.Context, teams []*v1alpha1.GitHubTeam) e
 				logger.WarnContext(
 					ctx,
 					"skip adding membership by user email, please provide user login instead",
-					"user email", u.GetEmail())
+					"user_email", u.GetEmail())
 				continue
 			}
 			if _, _, err := ghClient.Teams.AddTeamMembershipByID(
@@ -118,7 +118,7 @@ func (s *Synchronizer) Sync(ctx context.Context, teams []*v1alpha1.GitHubTeam) e
 				logger.InfoContext(
 					ctx,
 					"skip removing membership by user email, it is probably a pending invitation",
-					"user email", u.GetEmail())
+					"user_email", u.GetEmail())
 				continue
 			}
 			if _, err := ghClient.Teams.RemoveTeamMembershipByID(ctx, team.GetOrgId(), team.GetTeamId(), u.GetLogin()); err != nil {
@@ -198,7 +198,6 @@ func listActiveTeamMembers(
 	return users, resp, nil
 }
 
-// listPendingTeamInvitations a list of GitHub
 func listPendingTeamInvitations(
 	ctx context.Context,
 	c *github.Client,

--- a/pkg/github/synchronizer_test.go
+++ b/pkg/github/synchronizer_test.go
@@ -382,7 +382,8 @@ func testJSONMarshalGitHubUser(tb testing.TB, arr []string) []byte {
 	logins := make([]*github.User, len(arr))
 	for i, s := range arr {
 		if strings.Contains(s, "@") {
-			logins[i] = &github.User{Email: &s}
+			//nolint:exportloopref // loop variable is not reused in https://tip.golang.org/doc/go1.22.
+			logins[i] = &github.User{Email: &s} //#nosec G601 // loop variable is not reused.
 		} else {
 			//nolint:exportloopref // loop variable is not reused in https://tip.golang.org/doc/go1.22.
 			logins[i] = &github.User{Login: &s} //#nosec G601 // loop variable is not reused.


### PR DESCRIPTION
fix #18 

This is a bug encountered while testing, the invitation sent to an email is missing login and causing the program to panic.