### PR TITLE
Add Many to Many GroupSyncer

### DIFF
--- a/pkg/groupsync/groups.go
+++ b/pkg/groupsync/groups.go
@@ -1,0 +1,187 @@
+// Copyright 2024 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package groupsync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// ReadGroupClient provides read operations for a group system.
+type ReadGroupClient interface {
+	// Descendants retrieve all users (children, recursively) of a group.
+	Descendants(ctx context.Context, groupID string) ([]*User, error)
+
+	// GetGroup retrieves the Group with the given ID.
+	GetGroup(ctx context.Context, groupID string) (*Group, error)
+
+	// GetMembers retrieves the direct members (children) of the group with given ID.
+	GetMembers(ctx context.Context, groupID string) ([]Member, error)
+
+	// GetUser retrieves the User with the given ID.
+	GetUser(ctx context.Context, userID string) (*User, error)
+}
+
+// WriteGroupClient provides write operations for a group system.
+type WriteGroupClient interface {
+	// SetMembers replaces the members of the group with the given ID with the given members.
+	SetMembers(ctx context.Context, groupID string, members []Member) error
+}
+
+// ReadWriteGroupClient provides both read and write operations for a group system.
+type ReadWriteGroupClient interface {
+	ReadGroupClient
+	WriteGroupClient
+}
+
+// OneToManyGroupMapper maps group IDs to lists of group IDs.
+type OneToManyGroupMapper interface {
+	// AllGroupIDs returns the set of groupIDs being mapped (the key set).
+	AllGroupIDs(ctx context.Context) ([]string, error)
+
+	// ContainsGroupID returns whether this mapper contains a mapping for the given group ID.
+	ContainsGroupID(ctx context.Context, groupID string) (bool, error)
+
+	// MappedGroupIDs returns the list of group IDs mapped to the given group ID.
+	MappedGroupIDs(ctx context.Context, groupID string) ([]string, error)
+}
+
+// UserMapper maps a user ID to another user ID.
+type UserMapper interface {
+	// MappedUserID returns the user ID mapped to the given user ID.
+	MappedUserID(ctx context.Context, userID string) (string, error)
+}
+
+// User represents a user in a group system.
+type User struct {
+	// ID is the user's ID in the group system.
+	ID string `json:"id,omitempty"`
+	// Attributes represent arbitrary attributes about the user
+	// in the given group system. This field is typically set by
+	// the corresponding ReadGroupClient when retrieving the user.
+	Attributes any `json:"attributes,omitempty"`
+}
+
+// Group represents a group in a group system.
+type Group struct {
+	// ID is the group's ID in the group system.
+	ID string `json:"id,omitempty"`
+	// Attributes represent arbitrary attributes about the group
+	// in the given group system. This field is typically set by
+	// the corresponding ReadGroupClient when retrieving the group.
+	Attributes any `json:"attributes,omitempty"`
+}
+
+// Member represents a member of a group. A member may either be
+// a User or another Group. An instance of Member always be either
+// a User or a Group but not both.
+type Member interface {
+	// IsGroup returns whether this Member is a Group.
+	IsGroup() bool
+
+	// IsUser returns whether this Member is a User.
+	IsUser() bool
+
+	// Group returns the underlying group if this Member is a group.
+	// Otherwise, it returns an error.
+	Group() (*Group, error)
+
+	// User returns the underlying user if this Member is a user.
+	// Otherwise, it returns an error.
+	User() (*User, error)
+}
+
+// UserMember represents a user membership of a group.
+type UserMember struct {
+	Usr *User
+}
+
+// IsUser returns whether this Member is a User. Always returns true.
+func (u *UserMember) IsUser() bool {
+	return true
+}
+
+// IsGroup returns whether this Member is a Group. Always returns false.
+func (u *UserMember) IsGroup() bool {
+	return false
+}
+
+// Group returns an error.
+func (u *UserMember) Group() (*Group, error) {
+	return nil, fmt.Errorf("user is not a group")
+}
+
+// User returns the underlying user if this Member.
+func (u *UserMember) User() (*User, error) {
+	return u.Usr, nil
+}
+
+// GroupMember represents a group membership of a group.
+type GroupMember struct {
+	Grp *Group
+}
+
+// IsGroup returns whether this Member is a Group. Always returns true.
+func (g *GroupMember) IsGroup() bool {
+	return true
+}
+
+// IsUser returns whether this Member is a User. Always returns false.
+func (g *GroupMember) IsUser() bool {
+	return false
+}
+
+// Group returns the underlying group of this Member.
+func (g *GroupMember) Group() (*Group, error) {
+	return g.Grp, nil
+}
+
+// User returns an error.
+func (g *GroupMember) User() (*User, error) {
+	return nil, fmt.Errorf("group is not a user")
+}
+
+// Descendants retrieve all users (children, recursively) of the given
+// group ID using the given memberFunc. This function serves mostly as
+// a utility function when implementing ReadGroupClients for when there
+// is no special logic for fetching descendants.
+func Descendants(ctx context.Context, groupID string, memberFunc func(context.Context, string) ([]Member, error)) ([]*User, error) {
+	members, err := memberFunc(ctx, groupID)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching group members: %s, %w", groupID, err)
+	}
+	var users []*User
+	var merr error
+	for _, member := range members {
+		if member.IsUser() {
+			user, _ := member.User()
+			if user != nil {
+				users = append(users, user)
+			}
+		} else {
+			group, _ := member.Group()
+			if group != nil {
+				flattened, err := Descendants(ctx, group.ID, memberFunc)
+				if err != nil {
+					merr = errors.Join(merr, err)
+					continue
+				}
+				users = append(users, flattened...)
+			}
+		}
+	}
+	return users, merr
+}

--- a/pkg/groupsync/groups.go
+++ b/pkg/groupsync/groups.go
@@ -95,12 +95,22 @@ type Member interface {
 	// IsUser returns whether this Member is a User.
 	IsUser() bool
 
-	// Group returns the underlying group if this Member is a group.
-	// Otherwise, it returns an error.
+	// Group returns the underlying group if this Member is a group and never an error.
+	// Otherwise, if this member is a user, then it always returns an error and never a group.
+	// A common pattern is to use IsGroup as a guard before using this method:
+	//
+	//   if member.IsGroup() {
+	//      group, _ := member.Group()
+	//   }
 	Group() (*Group, error)
 
-	// User returns the underlying user if this Member is a user.
-	// Otherwise, it returns an error.
+	// User returns the underlying user if this Member is a user and never an error.
+	// Otherwise, if this member is a group, then it always returns an error and never a user.
+	// A common pattern is to use IsUser as a guard before using this method:
+	//
+	//   if member.IsUser() {
+	//      user, _ := member.User()
+	//   }
 	User() (*User, error)
 }
 

--- a/pkg/groupsync/groups.go
+++ b/pkg/groupsync/groups.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 )
 
-// ReadGroupClient provides read operations for a group system.
-type ReadGroupClient interface {
+// GroupReader provides read operations for a group system.
+type GroupReader interface {
 	// Descendants retrieve all users (children, recursively) of a group.
 	Descendants(ctx context.Context, groupID string) ([]*User, error)
 
@@ -35,16 +35,16 @@ type ReadGroupClient interface {
 	GetUser(ctx context.Context, userID string) (*User, error)
 }
 
-// WriteGroupClient provides write operations for a group system.
-type WriteGroupClient interface {
+// GroupWriter provides write operations for a group system.
+type GroupWriter interface {
 	// SetMembers replaces the members of the group with the given ID with the given members.
 	SetMembers(ctx context.Context, groupID string, members []Member) error
 }
 
-// ReadWriteGroupClient provides both read and write operations for a group system.
-type ReadWriteGroupClient interface {
-	ReadGroupClient
-	WriteGroupClient
+// GroupReadWriter provides both read and write operations for a group system.
+type GroupReadWriter interface {
+	GroupReader
+	GroupWriter
 }
 
 // OneToManyGroupMapper maps group IDs to lists of group IDs.
@@ -71,7 +71,7 @@ type User struct {
 	ID string `json:"id,omitempty"`
 	// Attributes represent arbitrary attributes about the user
 	// in the given group system. This field is typically set by
-	// the corresponding ReadGroupClient when retrieving the user.
+	// the corresponding GroupReader when retrieving the user.
 	Attributes any `json:"attributes,omitempty"`
 }
 
@@ -81,13 +81,13 @@ type Group struct {
 	ID string `json:"id,omitempty"`
 	// Attributes represent arbitrary attributes about the group
 	// in the given group system. This field is typically set by
-	// the corresponding ReadGroupClient when retrieving the group.
+	// the corresponding GroupReader when retrieving the group.
 	Attributes any `json:"attributes,omitempty"`
 }
 
 // Member represents a member of a group. A member may either be
-// a User or another Group. An instance of Member always be either
-// a User or a Group but not both.
+// a User or another Group. An instance of Member will always be
+// either a User or a Group but not both.
 type Member interface {
 	// IsGroup returns whether this Member is a Group.
 	IsGroup() bool

--- a/pkg/groupsync/manytomanysyncer.go
+++ b/pkg/groupsync/manytomanysyncer.go
@@ -1,0 +1,181 @@
+// Copyright 2024 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package groupsync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// ManyToManySyncer adheres to the v1alpha4.GroupSyncer interface.
+// This syncer allows for syncing many source groups to many target groups.
+// It adheres to the following policy when syncing a source group ID:
+//
+//  1. Find all the target groups that the given source group maps to.
+//  2. For each of those target groups, it finds all source groups that map to
+//     it and forms the union of all descendants from amongst those groups.
+//  3. This set of source users is then mapped to their corresponding target users
+//     forming the target member set.
+//  4. The target member set is then synced to the target group.
+type ManyToManySyncer struct {
+	sourceSystem      string
+	targetSystem      string
+	sourceGroupClient ReadGroupClient
+	targetGroupClient ReadWriteGroupClient
+	sourceGroupMapper OneToManyGroupMapper
+	targetGroupMapper OneToManyGroupMapper
+	userMapper        UserMapper
+}
+
+// NewManyToManySyncer creates a new ManyToManySyncer.
+func NewManyToManySyncer(
+	sourceSystem, targetSystem string,
+	sourceGroupClient ReadGroupClient,
+	targetGroupClient ReadWriteGroupClient,
+	sourceGroupMapper OneToManyGroupMapper,
+	targetGroupMapper OneToManyGroupMapper,
+	userMapper UserMapper,
+) *ManyToManySyncer {
+	return &ManyToManySyncer{
+		sourceSystem:      sourceSystem,
+		targetSystem:      targetSystem,
+		sourceGroupClient: sourceGroupClient,
+		targetGroupClient: targetGroupClient,
+		sourceGroupMapper: sourceGroupMapper,
+		targetGroupMapper: targetGroupMapper,
+		userMapper:        userMapper,
+	}
+}
+
+// SourceSystem returns the name of the source group system.
+func (f *ManyToManySyncer) SourceSystem() string {
+	return f.sourceSystem
+}
+
+// TargetSystem returns the name of the target group system.
+func (f *ManyToManySyncer) TargetSystem() string {
+	return f.targetSystem
+}
+
+// Sync syncs the source group with the given ID to the target group system.
+func (f *ManyToManySyncer) Sync(ctx context.Context, sourceGroupID string) error {
+	// get target group IDs for this source group ID
+	targetGroupIDs, err := f.sourceGroupMapper.MappedGroupIDs(ctx, sourceGroupID)
+	if err != nil {
+		return fmt.Errorf("error fetching target group IDs: %s, %w", sourceGroupID, err)
+	}
+
+	var merr error
+	for _, targetGroupID := range targetGroupIDs {
+		// get all source group IDs associated with the current target GroupID
+		sourceGroupIDs, err := f.targetGroupMapper.MappedGroupIDs(ctx, targetGroupID)
+		if err != nil {
+			merr = errors.Join(merr, fmt.Errorf("error getting associated source group ids: %w", err))
+			if len(sourceGroupIDs) == 0 {
+				// nothing left to do. move on to the next targetGroupID.
+				continue
+			}
+		}
+
+		// get the union of all users that are members of each source group
+		sourceUsers, err := f.sourceUsers(ctx, sourceGroupIDs)
+		if err != nil {
+			merr = errors.Join(merr, fmt.Errorf("error getting one or more source users: %w", err))
+			if len(sourceUsers) == 0 {
+				// nothing left to do. move on to the next targetGroupID.
+				continue
+			}
+		}
+
+		// map each source user to their corresponding target user
+		targetUsers, err := f.targetUsers(ctx, sourceUsers)
+		if err != nil {
+			merr = errors.Join(merr, fmt.Errorf("error getting one or more target users: %w", err))
+			if len(targetUsers) == 0 {
+				// nothing left to do. move on to the next targetGroupID.
+				continue
+			}
+		}
+
+		// map each targetUser to Member type
+		targetMembers := make([]Member, 0, len(targetUsers))
+		for _, user := range targetUsers {
+			targetMembers = append(targetMembers, &UserMember{Usr: user})
+		}
+
+		// targetMembers is now the canonical set of members for the target group ID.
+		// Set the target group's members to targetMembers.
+		if err := f.targetGroupClient.SetMembers(ctx, targetGroupID, targetMembers); err != nil {
+			merr = fmt.Errorf("error setting members to target group %s: %w", targetGroupID, err)
+		}
+	}
+
+	return merr
+}
+
+// SyncAll syncs all source groups that this GroupSyncer is aware of to the target system.
+func (f *ManyToManySyncer) SyncAll(ctx context.Context) error {
+	sourceGroupIDs, err := f.sourceGroupMapper.AllGroupIDs(ctx)
+	if err != nil {
+		return fmt.Errorf("error fetching source group IDs: %w", err)
+	}
+	var merr error
+	for _, sourceGroupID := range sourceGroupIDs {
+		if err := f.Sync(ctx, sourceGroupID); err != nil {
+			merr = errors.Join(merr, fmt.Errorf("error syncing source group %s: %w", sourceGroupID, err))
+		}
+	}
+	return merr
+}
+
+func (f *ManyToManySyncer) sourceUsers(ctx context.Context, sourceGroupIDs []string) ([]*User, error) {
+	var merr error
+	userMap := make(map[string]*User)
+	for _, sourceGroupID := range sourceGroupIDs {
+		sourceUsers, err := f.sourceGroupClient.Descendants(ctx, sourceGroupID)
+		if err != nil {
+			merr = errors.Join(merr, fmt.Errorf("error fetching source group users: %s, %w", sourceGroupID, err))
+			continue
+		}
+		for _, sourceUser := range sourceUsers {
+			userMap[sourceUser.ID] = sourceUser
+		}
+	}
+	users := make([]*User, 0, len(userMap))
+	for _, user := range userMap {
+		users = append(users, user)
+	}
+	return users, merr
+}
+
+func (f *ManyToManySyncer) targetUsers(ctx context.Context, sourceUsers []*User) ([]*User, error) {
+	var merr error
+	targetUsers := make([]*User, 0, len(sourceUsers))
+	for _, sourceUser := range sourceUsers {
+		targetUserID, err := f.userMapper.MappedUserID(ctx, sourceUser.ID)
+		if err != nil {
+			merr = fmt.Errorf("error mapping source user id %s to target user id: %w", sourceUser.ID, err)
+			continue
+		}
+		targetUser, err := f.targetGroupClient.GetUser(ctx, targetUserID)
+		if err != nil {
+			merr = fmt.Errorf("error fetching user for user id %s: %w", targetUserID, err)
+			continue
+		}
+		targetUsers = append(targetUsers, targetUser)
+	}
+	return targetUsers, merr
+}

--- a/pkg/groupsync/manytomanysyncer.go
+++ b/pkg/groupsync/manytomanysyncer.go
@@ -132,6 +132,7 @@ func (f *ManyToManySyncer) SyncAll(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("error fetching source group IDs: %w", err)
 	}
+	// TODO(https://github.com/abcxyz/team-link/issues/43): consider syncing each sourceGroupID async.
 	var merr error
 	for _, sourceGroupID := range sourceGroupIDs {
 		if err := f.Sync(ctx, sourceGroupID); err != nil {

--- a/pkg/groupsync/manytomanysyncer_test.go
+++ b/pkg/groupsync/manytomanysyncer_test.go
@@ -32,8 +32,8 @@ func TestSync(t *testing.T) {
 		name              string
 		sourceSystem      string
 		targetSystem      string
-		sourceGroupClient ReadGroupClient
-		targetGroupClient ReadWriteGroupClient
+		sourceGroupClient GroupReader
+		targetGroupClient GroupReadWriter
 		sourceGroupMapper OneToManyGroupMapper
 		targetGroupMapper OneToManyGroupMapper
 		userMapper        UserMapper
@@ -981,8 +981,8 @@ func TestSyncAll(t *testing.T) {
 		name              string
 		sourceSystem      string
 		targetSystem      string
-		sourceGroupClient ReadGroupClient
-		targetGroupClient ReadWriteGroupClient
+		sourceGroupClient GroupReader
+		targetGroupClient GroupReadWriter
 		sourceGroupMapper OneToManyGroupMapper
 		targetGroupMapper OneToManyGroupMapper
 		userMapper        UserMapper

--- a/pkg/groupsync/manytomanysyncer_test.go
+++ b/pkg/groupsync/manytomanysyncer_test.go
@@ -1,0 +1,1482 @@
+// Copyright 2024 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package groupsync
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/abcxyz/pkg/testutil"
+)
+
+func TestSync(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name              string
+		sourceSystem      string
+		targetSystem      string
+		sourceGroupClient ReadGroupClient
+		targetGroupClient ReadWriteGroupClient
+		sourceGroupMapper OneToManyGroupMapper
+		targetGroupMapper OneToManyGroupMapper
+		userMapper        UserMapper
+		syncID            string
+		want              map[string][]Member
+		wantErr           string
+	}{
+		{
+			name:         "simple_mapping",
+			sourceSystem: "source",
+			targetSystem: "target",
+			sourceGroupClient: &testReadWriteGroupClient{
+				groupMembers: map[string][]Member{
+					"1": {
+						&UserMember{Usr: &User{ID: "a"}},
+						&UserMember{Usr: &User{ID: "b"}},
+						&GroupMember{Grp: &Group{ID: "3"}},
+					},
+					"2": {
+						&UserMember{Usr: &User{ID: "c"}},
+					},
+					"3": {
+						&UserMember{Usr: &User{ID: "d"}},
+						&UserMember{Usr: &User{ID: "e"}},
+					},
+					"4": {
+						&GroupMember{Grp: &Group{ID: "1"}},
+						&GroupMember{Grp: &Group{ID: "2"}},
+					},
+					"5": {
+						&UserMember{Usr: &User{ID: "a"}},
+						&UserMember{Usr: &User{ID: "c"}},
+					},
+				},
+				users: map[string]*User{
+					"a": {ID: "a"},
+					"b": {ID: "b"},
+					"c": {ID: "c"},
+					"d": {ID: "d"},
+					"e": {ID: "e"},
+				},
+			},
+			targetGroupClient: &testReadWriteGroupClient{
+				groups: map[string]*Group{
+					"99": {ID: "99"},
+					"98": {ID: "98"},
+					"97": {ID: "97"},
+					"96": {ID: "96"},
+				},
+				users: map[string]*User{
+					"xy": {ID: "xy"},
+					"zw": {ID: "zw"},
+					"qr": {ID: "qr"},
+					"uv": {ID: "uv"},
+					"st": {ID: "st"},
+				},
+				groupMembers: map[string][]Member{
+					"99": {},
+					"98": {},
+					"97": {},
+					"96": {},
+				},
+			},
+			sourceGroupMapper: &testGroupMapper{
+				m: map[string][]string{
+					"1": {"99", "98"},
+					"2": {"97"},
+					"3": {"96"},
+					"4": {"97"},
+					"5": {"98"},
+				},
+			},
+			targetGroupMapper: &testGroupMapper{
+				m: map[string][]string{
+					"99": {"1"},
+					"98": {"1", "5"},
+					"97": {"2", "4"},
+					"96": {"3"},
+				},
+			},
+			userMapper: &testUserMapper{
+				m: map[string]string{
+					"a": "qr",
+					"b": "xy",
+					"c": "uv",
+					"d": "st",
+					"e": "zw",
+				},
+			},
+			syncID: "3",
+			want: map[string][]Member{
+				"96": {
+					&UserMember{Usr: &User{ID: "st"}},
+					&UserMember{Usr: &User{ID: "zw"}},
+				},
+				"97": {},
+				"98": {},
+				"99": {},
+			},
+		},
+		{
+			name:         "many_to_many_mapping",
+			sourceSystem: "source",
+			targetSystem: "target",
+			sourceGroupClient: &testReadWriteGroupClient{
+				groups: map[string]*Group{
+					"1": {ID: "1"},
+					"2": {ID: "3"},
+					"3": {ID: "4"},
+					"4": {ID: "5"},
+				},
+				groupMembers: map[string][]Member{
+					"1": {
+						&UserMember{Usr: &User{ID: "a"}},
+						&UserMember{Usr: &User{ID: "b"}},
+						&GroupMember{Grp: &Group{ID: "3"}},
+					},
+					"2": {
+						&UserMember{Usr: &User{ID: "c"}},
+					},
+					"3": {
+						&UserMember{Usr: &User{ID: "d"}},
+						&UserMember{Usr: &User{ID: "e"}},
+					},
+					"4": {
+						&GroupMember{Grp: &Group{ID: "1"}},
+						&GroupMember{Grp: &Group{ID: "2"}},
+					},
+					"5": {
+						&UserMember{Usr: &User{ID: "a"}},
+						&UserMember{Usr: &User{ID: "c"}},
+					},
+				},
+				users: map[string]*User{
+					"a": {ID: "a"},
+					"b": {ID: "b"},
+					"c": {ID: "c"},
+					"d": {ID: "d"},
+					"e": {ID: "e"},
+				},
+			},
+			targetGroupClient: &testReadWriteGroupClient{
+				groups: map[string]*Group{
+					"99": {ID: "99"},
+					"98": {ID: "98"},
+					"97": {ID: "97"},
+					"96": {ID: "96"},
+				},
+				users: map[string]*User{
+					"xy": {ID: "xy"},
+					"zw": {ID: "zw"},
+					"qr": {ID: "qr"},
+					"uv": {ID: "uv"},
+					"st": {ID: "st"},
+				},
+				groupMembers: map[string][]Member{
+					"99": {},
+					"98": {},
+					"97": {},
+					"96": {},
+				},
+			},
+			sourceGroupMapper: &testGroupMapper{
+				m: map[string][]string{
+					"1": {"99", "98"},
+					"2": {"97"},
+					"3": {"96"},
+					"4": {"97"},
+					"5": {"98"},
+				},
+			},
+			targetGroupMapper: &testGroupMapper{
+				m: map[string][]string{
+					"99": {"1"},
+					"98": {"1", "5"},
+					"97": {"2", "4"},
+					"96": {"3"},
+				},
+			},
+			userMapper: &testUserMapper{
+				m: map[string]string{
+					"a": "qr",
+					"b": "xy",
+					"c": "uv",
+					"d": "st",
+					"e": "zw",
+				},
+			},
+			syncID: "2",
+			want: map[string][]Member{
+				"96": {},
+				// Even though 2 contains one member, "c", we expect 97 to have
+				// more than one member. This is because group 4 also maps to 97.
+				// Thus, the union of the descendents of 2 and 4 will be mapped
+				// to 97.
+				"97": {
+					&UserMember{Usr: &User{ID: "qr"}},
+					&UserMember{Usr: &User{ID: "st"}},
+					&UserMember{Usr: &User{ID: "uv"}},
+					&UserMember{Usr: &User{ID: "xy"}},
+					&UserMember{Usr: &User{ID: "zw"}},
+				},
+				"98": {},
+				"99": {},
+			},
+		},
+		{
+			name:              "no_target_ids_found",
+			sourceSystem:      "source",
+			targetSystem:      "target",
+			sourceGroupClient: &testReadWriteGroupClient{},
+			targetGroupClient: &testReadWriteGroupClient{},
+			sourceGroupMapper: &testGroupMapper{},
+			targetGroupMapper: &testGroupMapper{},
+			userMapper:        &testUserMapper{},
+			syncID:            "45",
+			wantErr:           "error fetching target group IDs",
+		},
+		{
+			name:         "error_getting_associated_source_ids",
+			sourceSystem: "source",
+			targetSystem: "target",
+			sourceGroupClient: &testReadWriteGroupClient{
+				groups: map[string]*Group{
+					"1": {ID: "1"},
+					"2": {ID: "3"},
+					"3": {ID: "4"},
+					"4": {ID: "5"},
+				},
+				groupMembers: map[string][]Member{
+					"1": {
+						&UserMember{Usr: &User{ID: "a"}},
+						&UserMember{Usr: &User{ID: "b"}},
+						&GroupMember{Grp: &Group{ID: "3"}},
+					},
+					"2": {
+						&UserMember{Usr: &User{ID: "c"}},
+					},
+					"3": {
+						&UserMember{Usr: &User{ID: "d"}},
+						&UserMember{Usr: &User{ID: "e"}},
+					},
+					"4": {
+						&GroupMember{Grp: &Group{ID: "1"}},
+						&GroupMember{Grp: &Group{ID: "2"}},
+					},
+					"5": {
+						&UserMember{Usr: &User{ID: "a"}},
+						&UserMember{Usr: &User{ID: "c"}},
+					},
+				},
+				users: map[string]*User{
+					"a": {ID: "a"},
+					"b": {ID: "b"},
+					"c": {ID: "c"},
+					"d": {ID: "d"},
+					"e": {ID: "e"},
+				},
+			},
+			targetGroupClient: &testReadWriteGroupClient{
+				groups: map[string]*Group{
+					"99": {ID: "99"},
+					"98": {ID: "98"},
+					"97": {ID: "97"},
+					"96": {ID: "96"},
+				},
+				users: map[string]*User{
+					"xy": {ID: "xy"},
+					"zw": {ID: "zw"},
+					"qr": {ID: "qr"},
+					"uv": {ID: "uv"},
+					"st": {ID: "st"},
+				},
+				groupMembers: map[string][]Member{
+					"99": {},
+					"98": {},
+					"97": {},
+					"96": {},
+				},
+			},
+			sourceGroupMapper: &testGroupMapper{
+				m: map[string][]string{
+					"1": {"99", "98"},
+					"2": {"97"},
+					"3": {"96"},
+					"4": {"97"},
+					"5": {"98"},
+				},
+			},
+			targetGroupMapper: &testGroupMapper{
+				m: map[string][]string{
+					"99": {"1"},
+					"97": {"2", "4"},
+					"96": {"3"},
+				},
+			},
+			userMapper: &testUserMapper{
+				m: map[string]string{
+					"a": "qr",
+					"b": "xy",
+					"c": "uv",
+					"d": "st",
+					"e": "zw",
+				},
+			},
+			syncID: "1",
+			want: map[string][]Member{
+				"96": {},
+				"97": {},
+				"98": {},
+				"99": {
+					&UserMember{Usr: &User{ID: "qr"}},
+					&UserMember{Usr: &User{ID: "st"}},
+					&UserMember{Usr: &User{ID: "xy"}},
+					&UserMember{Usr: &User{ID: "zw"}},
+				},
+			},
+			wantErr: "error getting associated source group ids: group 98 not mapped",
+		},
+		{
+			name:         "error_getting_source_users_partial",
+			sourceSystem: "source",
+			targetSystem: "target",
+			sourceGroupClient: &testReadWriteGroupClient{
+				groups: map[string]*Group{
+					"1": {ID: "1"},
+					"2": {ID: "3"},
+					"3": {ID: "4"},
+					"4": {ID: "5"},
+				},
+				groupMembers: map[string][]Member{
+					"1": {
+						&UserMember{Usr: &User{ID: "a"}},
+						&UserMember{Usr: &User{ID: "b"}},
+						&GroupMember{Grp: &Group{ID: "3"}},
+					},
+					"2": {
+						&UserMember{Usr: &User{ID: "c"}},
+					},
+					"3": {
+						&UserMember{Usr: &User{ID: "d"}},
+						&UserMember{Usr: &User{ID: "e"}},
+					},
+					"4": {
+						&GroupMember{Grp: &Group{ID: "1"}},
+						&GroupMember{Grp: &Group{ID: "2"}},
+					},
+				},
+				users: map[string]*User{
+					"a": {ID: "a"},
+					"b": {ID: "b"},
+					"c": {ID: "c"},
+					"d": {ID: "d"},
+					"e": {ID: "e"},
+				},
+			},
+			targetGroupClient: &testReadWriteGroupClient{
+				groups: map[string]*Group{
+					"99": {ID: "99"},
+					"98": {ID: "98"},
+					"97": {ID: "97"},
+					"96": {ID: "96"},
+				},
+				users: map[string]*User{
+					"xy": {ID: "xy"},
+					"zw": {ID: "zw"},
+					"qr": {ID: "qr"},
+					"uv": {ID: "uv"},
+					"st": {ID: "st"},
+				},
+				groupMembers: map[string][]Member{
+					"99": {},
+					"98": {},
+					"97": {},
+					"96": {},
+				},
+			},
+			sourceGroupMapper: &testGroupMapper{
+				m: map[string][]string{
+					"1": {"99", "98"},
+					"2": {"97"},
+					"3": {"96"},
+					"4": {"97"},
+					"5": {"98"},
+				},
+			},
+			targetGroupMapper: &testGroupMapper{
+				m: map[string][]string{
+					"99": {"1"},
+					"98": {"1", "5"},
+					"97": {"2", "4"},
+					"96": {"3"},
+				},
+			},
+			userMapper: &testUserMapper{
+				m: map[string]string{
+					"a": "qr",
+					"b": "xy",
+					"c": "uv",
+					"d": "st",
+					"e": "zw",
+				},
+			},
+			syncID: "1",
+			want: map[string][]Member{
+				"96": {},
+				"97": {},
+				"98": {
+					&UserMember{Usr: &User{ID: "qr"}},
+					&UserMember{Usr: &User{ID: "st"}},
+					&UserMember{Usr: &User{ID: "xy"}},
+					&UserMember{Usr: &User{ID: "zw"}},
+				},
+				"99": {
+					&UserMember{Usr: &User{ID: "qr"}},
+					&UserMember{Usr: &User{ID: "st"}},
+					&UserMember{Usr: &User{ID: "xy"}},
+					&UserMember{Usr: &User{ID: "zw"}},
+				},
+			},
+			wantErr: "error getting one or more source users",
+		},
+		{
+			name:         "error_getting_source_users_total",
+			sourceSystem: "source",
+			targetSystem: "target",
+			sourceGroupClient: &testReadWriteGroupClient{
+				groups: map[string]*Group{
+					"1": {ID: "1"},
+					"2": {ID: "3"},
+					"3": {ID: "4"},
+					"4": {ID: "5"},
+				},
+				groupMembers: map[string][]Member{
+					"2": {
+						&UserMember{Usr: &User{ID: "c"}},
+					},
+					"3": {
+						&UserMember{Usr: &User{ID: "d"}},
+						&UserMember{Usr: &User{ID: "e"}},
+					},
+					"4": {
+						&GroupMember{Grp: &Group{ID: "1"}},
+						&GroupMember{Grp: &Group{ID: "2"}},
+					},
+				},
+				users: map[string]*User{
+					"a": {ID: "a"},
+					"b": {ID: "b"},
+					"c": {ID: "c"},
+					"d": {ID: "d"},
+					"e": {ID: "e"},
+				},
+			},
+			targetGroupClient: &testReadWriteGroupClient{
+				groups: map[string]*Group{
+					"99": {ID: "99"},
+					"98": {ID: "98"},
+					"97": {ID: "97"},
+					"96": {ID: "96"},
+				},
+				users: map[string]*User{
+					"xy": {ID: "xy"},
+					"zw": {ID: "zw"},
+					"qr": {ID: "qr"},
+					"uv": {ID: "uv"},
+					"st": {ID: "st"},
+				},
+				groupMembers: map[string][]Member{
+					"99": {},
+					"98": {},
+					"97": {},
+					"96": {},
+				},
+			},
+			sourceGroupMapper: &testGroupMapper{
+				m: map[string][]string{
+					"1": {"99", "98"},
+					"2": {"97"},
+					"3": {"96"},
+					"4": {"97"},
+					"5": {"98"},
+				},
+			},
+			targetGroupMapper: &testGroupMapper{
+				m: map[string][]string{
+					"99": {"1"},
+					"98": {"1", "5"},
+					"97": {"2", "4"},
+					"96": {"3"},
+				},
+			},
+			userMapper: &testUserMapper{
+				m: map[string]string{
+					"a": "qr",
+					"b": "xy",
+					"c": "uv",
+					"d": "st",
+					"e": "zw",
+				},
+			},
+			syncID: "1",
+			want: map[string][]Member{
+				"99": {},
+				"98": {},
+			},
+			wantErr: "error getting one or more source users",
+		},
+		{
+			name:         "error_mapping_source_users_partial",
+			sourceSystem: "source",
+			targetSystem: "target",
+			sourceGroupClient: &testReadWriteGroupClient{
+				groups: map[string]*Group{
+					"1": {ID: "1"},
+					"2": {ID: "3"},
+					"3": {ID: "4"},
+					"4": {ID: "5"},
+				},
+				groupMembers: map[string][]Member{
+					"1": {
+						&UserMember{Usr: &User{ID: "a"}},
+						&UserMember{Usr: &User{ID: "b"}},
+						&GroupMember{Grp: &Group{ID: "3"}},
+					},
+					"2": {
+						&UserMember{Usr: &User{ID: "c"}},
+					},
+					"3": {
+						&UserMember{Usr: &User{ID: "d"}},
+						&UserMember{Usr: &User{ID: "e"}},
+					},
+					"4": {
+						&GroupMember{Grp: &Group{ID: "1"}},
+						&GroupMember{Grp: &Group{ID: "2"}},
+					},
+					"5": {
+						&UserMember{Usr: &User{ID: "a"}},
+						&UserMember{Usr: &User{ID: "c"}},
+					},
+				},
+				users: map[string]*User{
+					"a": {ID: "a"},
+					"b": {ID: "b"},
+					"c": {ID: "c"},
+					"d": {ID: "d"},
+					"e": {ID: "e"},
+				},
+			},
+			targetGroupClient: &testReadWriteGroupClient{
+				groups: map[string]*Group{
+					"99": {ID: "99"},
+					"98": {ID: "98"},
+					"97": {ID: "97"},
+					"96": {ID: "96"},
+				},
+				users: map[string]*User{
+					"xy": {ID: "xy"},
+					"zw": {ID: "zw"},
+					"qr": {ID: "qr"},
+					"uv": {ID: "uv"},
+					"st": {ID: "st"},
+				},
+				groupMembers: map[string][]Member{
+					"99": {},
+					"98": {},
+					"97": {},
+					"96": {},
+				},
+			},
+			sourceGroupMapper: &testGroupMapper{
+				m: map[string][]string{
+					"1": {"99", "98"},
+					"2": {"97"},
+					"3": {"96"},
+					"4": {"97"},
+					"5": {"98"},
+				},
+			},
+			targetGroupMapper: &testGroupMapper{
+				m: map[string][]string{
+					"99": {"1"},
+					"98": {"1", "5"},
+					"97": {"2", "4"},
+					"96": {"3"},
+				},
+			},
+			userMapper: &testUserMapper{
+				m: map[string]string{
+					"d": "st",
+					"e": "zw",
+				},
+			},
+			syncID: "1",
+			want: map[string][]Member{
+				"96": {},
+				"97": {},
+				"98": {
+					&UserMember{Usr: &User{ID: "st"}},
+					&UserMember{Usr: &User{ID: "zw"}},
+				},
+				"99": {
+					&UserMember{Usr: &User{ID: "st"}},
+					&UserMember{Usr: &User{ID: "zw"}},
+				},
+			},
+			wantErr: "error getting one or more target users",
+		},
+		{
+			name:         "error_mapping_source_users_total",
+			sourceSystem: "source",
+			targetSystem: "target",
+			sourceGroupClient: &testReadWriteGroupClient{
+				groups: map[string]*Group{
+					"1": {ID: "1"},
+					"2": {ID: "3"},
+					"3": {ID: "4"},
+					"4": {ID: "5"},
+				},
+				groupMembers: map[string][]Member{
+					"1": {
+						&UserMember{Usr: &User{ID: "a"}},
+						&UserMember{Usr: &User{ID: "b"}},
+						&GroupMember{Grp: &Group{ID: "3"}},
+					},
+					"2": {
+						&UserMember{Usr: &User{ID: "c"}},
+					},
+					"3": {
+						&UserMember{Usr: &User{ID: "d"}},
+						&UserMember{Usr: &User{ID: "e"}},
+					},
+					"4": {
+						&GroupMember{Grp: &Group{ID: "1"}},
+						&GroupMember{Grp: &Group{ID: "2"}},
+					},
+					"5": {
+						&UserMember{Usr: &User{ID: "a"}},
+						&UserMember{Usr: &User{ID: "c"}},
+					},
+				},
+				users: map[string]*User{
+					"a": {ID: "a"},
+					"b": {ID: "b"},
+					"c": {ID: "c"},
+					"d": {ID: "d"},
+					"e": {ID: "e"},
+				},
+			},
+			targetGroupClient: &testReadWriteGroupClient{
+				groups: map[string]*Group{
+					"99": {ID: "99"},
+					"98": {ID: "98"},
+					"97": {ID: "97"},
+					"96": {ID: "96"},
+				},
+				users: map[string]*User{
+					"xy": {ID: "xy"},
+					"zw": {ID: "zw"},
+					"qr": {ID: "qr"},
+					"uv": {ID: "uv"},
+					"st": {ID: "st"},
+				},
+				groupMembers: map[string][]Member{
+					"99": {},
+					"98": {},
+					"97": {},
+					"96": {},
+				},
+			},
+			sourceGroupMapper: &testGroupMapper{
+				m: map[string][]string{
+					"1": {"99", "98"},
+					"2": {"97"},
+					"3": {"96"},
+					"4": {"97"},
+					"5": {"98"},
+				},
+			},
+			targetGroupMapper: &testGroupMapper{
+				m: map[string][]string{
+					"99": {"1"},
+					"98": {"1", "5"},
+					"97": {"2", "4"},
+					"96": {"3"},
+				},
+			},
+			userMapper: &testUserMapper{},
+			syncID:     "1",
+			want: map[string][]Member{
+				"96": {},
+				"97": {},
+				"98": {},
+				"99": {},
+			},
+			wantErr: "error getting one or more target users",
+		},
+		{
+			name:         "error_setting_members_partial",
+			sourceSystem: "source",
+			targetSystem: "target",
+			sourceGroupClient: &testReadWriteGroupClient{
+				groups: map[string]*Group{
+					"1": {ID: "1"},
+					"2": {ID: "3"},
+					"3": {ID: "4"},
+					"4": {ID: "5"},
+				},
+				groupMembers: map[string][]Member{
+					"1": {
+						&UserMember{Usr: &User{ID: "a"}},
+						&UserMember{Usr: &User{ID: "b"}},
+						&GroupMember{Grp: &Group{ID: "3"}},
+					},
+					"2": {
+						&UserMember{Usr: &User{ID: "c"}},
+					},
+					"3": {
+						&UserMember{Usr: &User{ID: "d"}},
+						&UserMember{Usr: &User{ID: "e"}},
+					},
+					"4": {
+						&GroupMember{Grp: &Group{ID: "1"}},
+						&GroupMember{Grp: &Group{ID: "2"}},
+					},
+					"5": {
+						&UserMember{Usr: &User{ID: "a"}},
+						&UserMember{Usr: &User{ID: "c"}},
+					},
+				},
+				users: map[string]*User{
+					"a": {ID: "a"},
+					"b": {ID: "b"},
+					"c": {ID: "c"},
+					"d": {ID: "d"},
+					"e": {ID: "e"},
+				},
+			},
+			targetGroupClient: &testReadWriteGroupClient{
+				groups: map[string]*Group{
+					"99": {ID: "99"},
+					"98": {ID: "98"},
+					"97": {ID: "97"},
+					"96": {ID: "96"},
+				},
+				users: map[string]*User{
+					"xy": {ID: "xy"},
+					"zw": {ID: "zw"},
+					"qr": {ID: "qr"},
+					"uv": {ID: "uv"},
+					"st": {ID: "st"},
+				},
+				groupMembers: map[string][]Member{
+					"99": {},
+					"98": {},
+					"97": {},
+					"96": {},
+				},
+				setMembersErrs: map[string]error{
+					"99": fmt.Errorf("error setting members for group 99"),
+				},
+			},
+			sourceGroupMapper: &testGroupMapper{
+				m: map[string][]string{
+					"1": {"99", "98"},
+					"2": {"97"},
+					"3": {"96"},
+					"4": {"97"},
+					"5": {"98"},
+				},
+			},
+			targetGroupMapper: &testGroupMapper{
+				m: map[string][]string{
+					"99": {"1"},
+					"98": {"1", "5"},
+					"97": {"2", "4"},
+					"96": {"3"},
+				},
+			},
+			userMapper: &testUserMapper{
+				m: map[string]string{
+					"a": "qr",
+					"b": "xy",
+					"c": "uv",
+					"d": "st",
+					"e": "zw",
+				},
+			},
+			syncID: "1",
+			want: map[string][]Member{
+				"96": {},
+				"97": {},
+				"98": {
+					&UserMember{Usr: &User{ID: "qr"}},
+					&UserMember{Usr: &User{ID: "st"}},
+					&UserMember{Usr: &User{ID: "uv"}},
+					&UserMember{Usr: &User{ID: "xy"}},
+					&UserMember{Usr: &User{ID: "zw"}},
+				},
+				"99": {},
+			},
+			wantErr: "error setting members for group 99",
+		},
+		{
+			name:         "error_setting_members_total",
+			sourceSystem: "source",
+			targetSystem: "target",
+			sourceGroupClient: &testReadWriteGroupClient{
+				groups: map[string]*Group{
+					"1": {ID: "1"},
+					"2": {ID: "3"},
+					"3": {ID: "4"},
+					"4": {ID: "5"},
+				},
+				groupMembers: map[string][]Member{
+					"1": {
+						&UserMember{Usr: &User{ID: "a"}},
+						&UserMember{Usr: &User{ID: "b"}},
+						&GroupMember{Grp: &Group{ID: "3"}},
+					},
+					"2": {
+						&UserMember{Usr: &User{ID: "c"}},
+					},
+					"3": {
+						&UserMember{Usr: &User{ID: "d"}},
+						&UserMember{Usr: &User{ID: "e"}},
+					},
+					"4": {
+						&GroupMember{Grp: &Group{ID: "1"}},
+						&GroupMember{Grp: &Group{ID: "2"}},
+					},
+					"5": {
+						&UserMember{Usr: &User{ID: "a"}},
+						&UserMember{Usr: &User{ID: "c"}},
+					},
+				},
+				users: map[string]*User{
+					"a": {ID: "a"},
+					"b": {ID: "b"},
+					"c": {ID: "c"},
+					"d": {ID: "d"},
+					"e": {ID: "e"},
+				},
+			},
+			targetGroupClient: &testReadWriteGroupClient{
+				groups: map[string]*Group{
+					"99": {ID: "99"},
+					"98": {ID: "98"},
+					"97": {ID: "97"},
+					"96": {ID: "96"},
+				},
+				users: map[string]*User{
+					"xy": {ID: "xy"},
+					"zw": {ID: "zw"},
+					"qr": {ID: "qr"},
+					"uv": {ID: "uv"},
+					"st": {ID: "st"},
+				},
+				groupMembers: map[string][]Member{
+					"99": {},
+					"98": {},
+					"97": {},
+					"96": {},
+				},
+				setMembersErrs: map[string]error{
+					"98": fmt.Errorf("error setting members for group 98"),
+					"99": fmt.Errorf("error setting members for group 99"),
+				},
+			},
+			sourceGroupMapper: &testGroupMapper{
+				m: map[string][]string{
+					"1": {"99", "98"},
+					"2": {"97"},
+					"3": {"96"},
+					"4": {"97"},
+					"5": {"98"},
+				},
+			},
+			targetGroupMapper: &testGroupMapper{
+				m: map[string][]string{
+					"99": {"1"},
+					"98": {"1", "5"},
+					"97": {"2", "4"},
+					"96": {"3"},
+				},
+			},
+			userMapper: &testUserMapper{
+				m: map[string]string{
+					"a": "qr",
+					"b": "xy",
+					"c": "uv",
+					"d": "st",
+					"e": "zw",
+				},
+			},
+			syncID: "1",
+			want: map[string][]Member{
+				"96": {},
+				"97": {},
+				"98": {},
+				"99": {},
+			},
+			wantErr: "error setting members for group",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			syncer := NewManyToManySyncer(
+				tc.sourceSystem,
+				tc.targetSystem,
+				tc.sourceGroupClient,
+				tc.targetGroupClient,
+				tc.sourceGroupMapper,
+				tc.targetGroupMapper,
+				tc.userMapper,
+			)
+
+			err := syncer.Sync(ctx, tc.syncID)
+			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
+				t.Errorf("unexpected error (-want, +got):\n%s", diff)
+			}
+			for targetGroupID := range tc.want {
+				got, err := tc.targetGroupClient.GetMembers(ctx, targetGroupID)
+				if err != nil {
+					// test data misconfigured. fail fast
+					t.Fatalf("test data misconfigured. failed to get target group members: %v", err)
+				}
+				if diff := cmp.Diff(got, tc.want[targetGroupID]); diff != "" {
+					t.Errorf("unexpected result for targetGroupID %s (-got, +want): \n%s", targetGroupID, diff)
+				}
+			}
+		})
+	}
+}
+
+func TestSyncAll(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name              string
+		sourceSystem      string
+		targetSystem      string
+		sourceGroupClient ReadGroupClient
+		targetGroupClient ReadWriteGroupClient
+		sourceGroupMapper OneToManyGroupMapper
+		targetGroupMapper OneToManyGroupMapper
+		userMapper        UserMapper
+		want              map[string][]Member
+		wantErr           string
+	}{
+		{
+			name:         "sync_all_success",
+			sourceSystem: "source",
+			targetSystem: "target",
+			sourceGroupClient: &testReadWriteGroupClient{
+				groupMembers: map[string][]Member{
+					"1": {
+						&UserMember{Usr: &User{ID: "a"}},
+						&UserMember{Usr: &User{ID: "b"}},
+						&GroupMember{Grp: &Group{ID: "3"}},
+					},
+					"2": {
+						&UserMember{Usr: &User{ID: "c"}},
+					},
+					"3": {
+						&UserMember{Usr: &User{ID: "d"}},
+						&UserMember{Usr: &User{ID: "e"}},
+					},
+					"4": {
+						&GroupMember{Grp: &Group{ID: "1"}},
+						&GroupMember{Grp: &Group{ID: "2"}},
+					},
+					"5": {
+						&UserMember{Usr: &User{ID: "a"}},
+						&UserMember{Usr: &User{ID: "c"}},
+					},
+				},
+				users: map[string]*User{
+					"a": {ID: "a"},
+					"b": {ID: "b"},
+					"c": {ID: "c"},
+					"d": {ID: "d"},
+					"e": {ID: "e"},
+				},
+			},
+			targetGroupClient: &testReadWriteGroupClient{
+				groups: map[string]*Group{
+					"99": {ID: "99"},
+					"98": {ID: "98"},
+					"97": {ID: "97"},
+					"96": {ID: "96"},
+				},
+				users: map[string]*User{
+					"xy": {ID: "xy"},
+					"zw": {ID: "zw"},
+					"qr": {ID: "qr"},
+					"uv": {ID: "uv"},
+					"st": {ID: "st"},
+				},
+				groupMembers: map[string][]Member{
+					"99": {},
+					"98": {},
+					"97": {},
+					"96": {},
+				},
+			},
+			sourceGroupMapper: &testGroupMapper{
+				m: map[string][]string{
+					"1": {"99", "98"},
+					"2": {"97"},
+					"3": {"96"},
+					"4": {"97"},
+					"5": {"98"},
+				},
+			},
+			targetGroupMapper: &testGroupMapper{
+				m: map[string][]string{
+					"99": {"1"},
+					"98": {"1", "5"},
+					"97": {"2", "4"},
+					"96": {"3"},
+				},
+			},
+			userMapper: &testUserMapper{
+				m: map[string]string{
+					"a": "qr",
+					"b": "xy",
+					"c": "uv",
+					"d": "st",
+					"e": "zw",
+				},
+			},
+			want: map[string][]Member{
+				"96": {
+					&UserMember{Usr: &User{ID: "st"}},
+					&UserMember{Usr: &User{ID: "zw"}},
+				},
+				"97": {
+					&UserMember{Usr: &User{ID: "qr"}},
+					&UserMember{Usr: &User{ID: "st"}},
+					&UserMember{Usr: &User{ID: "uv"}},
+					&UserMember{Usr: &User{ID: "xy"}},
+					&UserMember{Usr: &User{ID: "zw"}},
+				},
+				"98": {
+					&UserMember{Usr: &User{ID: "qr"}},
+					&UserMember{Usr: &User{ID: "st"}},
+					&UserMember{Usr: &User{ID: "uv"}},
+					&UserMember{Usr: &User{ID: "xy"}},
+					&UserMember{Usr: &User{ID: "zw"}},
+				},
+				"99": {
+					&UserMember{Usr: &User{ID: "qr"}},
+					&UserMember{Usr: &User{ID: "st"}},
+					&UserMember{Usr: &User{ID: "xy"}},
+					&UserMember{Usr: &User{ID: "zw"}},
+				},
+			},
+		},
+		{
+			name:              "no_source_ids_found",
+			sourceSystem:      "source",
+			targetSystem:      "target",
+			sourceGroupClient: &testReadWriteGroupClient{},
+			targetGroupClient: &testReadWriteGroupClient{},
+			sourceGroupMapper: &testGroupMapper{
+				allGroupIDsErr: fmt.Errorf("allGroupIDsErr"),
+			},
+			targetGroupMapper: &testGroupMapper{},
+			userMapper:        &testUserMapper{},
+			wantErr:           "error fetching source group IDs",
+		},
+		{
+			name:         "sync_all_partial_failure",
+			sourceSystem: "source",
+			targetSystem: "target",
+			sourceGroupClient: &testReadWriteGroupClient{
+				groupMembers: map[string][]Member{
+					"1": {
+						&UserMember{Usr: &User{ID: "a"}},
+						&UserMember{Usr: &User{ID: "b"}},
+						&GroupMember{Grp: &Group{ID: "3"}},
+					},
+					"2": {
+						&UserMember{Usr: &User{ID: "c"}},
+					},
+					"3": {
+						&UserMember{Usr: &User{ID: "d"}},
+						&UserMember{Usr: &User{ID: "e"}},
+					},
+					"4": {
+						&GroupMember{Grp: &Group{ID: "1"}},
+						&GroupMember{Grp: &Group{ID: "2"}},
+					},
+					"5": {
+						&UserMember{Usr: &User{ID: "a"}},
+						&UserMember{Usr: &User{ID: "c"}},
+					},
+				},
+				users: map[string]*User{
+					"a": {ID: "a"},
+					"b": {ID: "b"},
+					"c": {ID: "c"},
+					"d": {ID: "d"},
+					"e": {ID: "e"},
+				},
+			},
+			targetGroupClient: &testReadWriteGroupClient{
+				groups: map[string]*Group{
+					"99": {ID: "99"},
+					"98": {ID: "98"},
+					"97": {ID: "97"},
+					"96": {ID: "96"},
+				},
+				users: map[string]*User{
+					"xy": {ID: "xy"},
+					"zw": {ID: "zw"},
+					"qr": {ID: "qr"},
+					"uv": {ID: "uv"},
+					"st": {ID: "st"},
+				},
+				groupMembers: map[string][]Member{
+					"99": {},
+					"98": {},
+					"97": {},
+					"96": {},
+				},
+			},
+			sourceGroupMapper: &testGroupMapper{
+				m: map[string][]string{
+					"1": {"98", "99"},
+					"2": {"97"},
+					"3": {"96"},
+					"4": {"97"},
+					"5": {"98"},
+				},
+				mappedGroupIdsErr: map[string]error{
+					"1": fmt.Errorf("mappedGroupIdsErr"),
+				},
+			},
+			targetGroupMapper: &testGroupMapper{
+				m: map[string][]string{
+					"99": {"1"},
+					"98": {"1", "5"},
+					"97": {"2", "4"},
+					"96": {"3"},
+				},
+			},
+			userMapper: &testUserMapper{
+				m: map[string]string{
+					"a": "qr",
+					"b": "xy",
+					"c": "uv",
+					"d": "st",
+					"e": "zw",
+				},
+			},
+			want: map[string][]Member{
+				"96": {
+					&UserMember{Usr: &User{ID: "st"}},
+					&UserMember{Usr: &User{ID: "zw"}},
+				},
+				"97": {
+					&UserMember{Usr: &User{ID: "qr"}},
+					&UserMember{Usr: &User{ID: "st"}},
+					&UserMember{Usr: &User{ID: "uv"}},
+					&UserMember{Usr: &User{ID: "xy"}},
+					&UserMember{Usr: &User{ID: "zw"}},
+				},
+				"98": {
+					&UserMember{Usr: &User{ID: "qr"}},
+					&UserMember{Usr: &User{ID: "st"}},
+					&UserMember{Usr: &User{ID: "uv"}},
+					&UserMember{Usr: &User{ID: "xy"}},
+					&UserMember{Usr: &User{ID: "zw"}},
+				},
+				"99": {},
+			},
+			wantErr: "error syncing source group 1",
+		},
+		{
+			name:         "sync_all_total_failure",
+			sourceSystem: "source",
+			targetSystem: "target",
+			sourceGroupClient: &testReadWriteGroupClient{
+				groupMembers: map[string][]Member{
+					"1": {
+						&UserMember{Usr: &User{ID: "a"}},
+						&UserMember{Usr: &User{ID: "b"}},
+						&GroupMember{Grp: &Group{ID: "3"}},
+					},
+					"2": {
+						&UserMember{Usr: &User{ID: "c"}},
+					},
+					"3": {
+						&UserMember{Usr: &User{ID: "d"}},
+						&UserMember{Usr: &User{ID: "e"}},
+					},
+					"4": {
+						&GroupMember{Grp: &Group{ID: "1"}},
+						&GroupMember{Grp: &Group{ID: "2"}},
+					},
+					"5": {
+						&UserMember{Usr: &User{ID: "a"}},
+						&UserMember{Usr: &User{ID: "c"}},
+					},
+				},
+				users: map[string]*User{
+					"a": {ID: "a"},
+					"b": {ID: "b"},
+					"c": {ID: "c"},
+					"d": {ID: "d"},
+					"e": {ID: "e"},
+				},
+			},
+			targetGroupClient: &testReadWriteGroupClient{
+				groups: map[string]*Group{
+					"99": {ID: "99"},
+					"98": {ID: "98"},
+					"97": {ID: "97"},
+					"96": {ID: "96"},
+				},
+				users: map[string]*User{
+					"xy": {ID: "xy"},
+					"zw": {ID: "zw"},
+					"qr": {ID: "qr"},
+					"uv": {ID: "uv"},
+					"st": {ID: "st"},
+				},
+				groupMembers: map[string][]Member{
+					"99": {},
+					"98": {},
+					"97": {},
+					"96": {},
+				},
+			},
+			sourceGroupMapper: &testGroupMapper{
+				m: map[string][]string{
+					"1": {"98", "99"},
+					"2": {"97"},
+					"3": {"96"},
+					"4": {"97"},
+					"5": {"98"},
+				},
+				mappedGroupIdsErr: map[string]error{
+					"1": fmt.Errorf("mappedGroupIdsErr"),
+					"2": fmt.Errorf("mappedGroupIdsErr"),
+					"3": fmt.Errorf("mappedGroupIdsErr"),
+					"4": fmt.Errorf("mappedGroupIdsErr"),
+					"5": fmt.Errorf("mappedGroupIdsErr"),
+				},
+			},
+			targetGroupMapper: &testGroupMapper{
+				m: map[string][]string{
+					"99": {"1"},
+					"98": {"1", "5"},
+					"97": {"2", "4"},
+					"96": {"3"},
+				},
+			},
+			userMapper: &testUserMapper{
+				m: map[string]string{
+					"a": "qr",
+					"b": "xy",
+					"c": "uv",
+					"d": "st",
+					"e": "zw",
+				},
+			},
+			want: map[string][]Member{
+				"96": {},
+				"97": {},
+				"98": {},
+				"99": {},
+			},
+			wantErr: "error syncing source group",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			syncer := NewManyToManySyncer(
+				tc.sourceSystem,
+				tc.targetSystem,
+				tc.sourceGroupClient,
+				tc.targetGroupClient,
+				tc.sourceGroupMapper,
+				tc.targetGroupMapper,
+				tc.userMapper,
+			)
+
+			err := syncer.SyncAll(ctx)
+			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
+				t.Errorf("unexpected error (-want, +got):\n%s", diff)
+			}
+			for targetGroupID := range tc.want {
+				got, err := tc.targetGroupClient.GetMembers(ctx, targetGroupID)
+				if err != nil {
+					// test data misconfigured. fail fast
+					t.Fatalf("test data misconfigured. failed to get target group members: %v", err)
+				}
+				if diff := cmp.Diff(got, tc.want[targetGroupID]); diff != "" {
+					t.Errorf("unexpected result for targetGroupID %s (-got, +want): \n%s", targetGroupID, diff)
+				}
+			}
+		})
+	}
+}
+
+type testReadWriteGroupClient struct {
+	groups          map[string]*Group
+	groupMembers    map[string][]Member
+	users           map[string]*User
+	descendantsErrs map[string]error
+	getGroupErrs    map[string]error
+	getMembersErrs  map[string]error
+	getUserErrs     map[string]error
+	setMembersErrs  map[string]error
+}
+
+func (tc *testReadWriteGroupClient) Descendants(ctx context.Context, groupID string) ([]*User, error) {
+	if err, ok := tc.descendantsErrs[groupID]; ok {
+		return nil, err
+	}
+	return Descendants(ctx, groupID, tc.GetMembers)
+}
+
+func (tc *testReadWriteGroupClient) GetGroup(ctx context.Context, groupID string) (*Group, error) {
+	if err, ok := tc.getGroupErrs[groupID]; ok {
+		return nil, err
+	}
+	group, ok := tc.groups[groupID]
+	if !ok {
+		return nil, fmt.Errorf("group %s not found", groupID)
+	}
+	return group, nil
+}
+
+func (tc *testReadWriteGroupClient) GetMembers(ctx context.Context, groupID string) ([]Member, error) {
+	if err, ok := tc.getMembersErrs[groupID]; ok {
+		return nil, err
+	}
+	members, ok := tc.groupMembers[groupID]
+	if !ok {
+		return nil, fmt.Errorf("group %s not found", groupID)
+	}
+	return members, nil
+}
+
+func (tc *testReadWriteGroupClient) GetUser(ctx context.Context, userID string) (*User, error) {
+	if err, ok := tc.getUserErrs[userID]; ok {
+		return nil, err
+	}
+	user, ok := tc.users[userID]
+	if !ok {
+		return nil, fmt.Errorf("user %s not found", userID)
+	}
+	return user, nil
+}
+
+func (tc *testReadWriteGroupClient) SetMembers(ctx context.Context, groupID string, members []Member) error {
+	if err, ok := tc.setMembersErrs[groupID]; ok {
+		return err
+	}
+	if _, ok := tc.groupMembers[groupID]; !ok {
+		return fmt.Errorf("group %s not found", groupID)
+	}
+	// sort members so we have deterministic ordering for comparisons
+	sort.Slice(members, func(i, j int) bool {
+		u1, err := members[i].User()
+		if err != nil {
+			// test is broken if this happens
+			panic(err)
+		}
+		u2, err := members[j].User()
+		if err != nil {
+			// test is broken if this happens
+			panic(err)
+		}
+		return u1.ID < u2.ID
+	})
+	tc.groupMembers[groupID] = members
+	return nil
+}
+
+type testGroupMapper struct {
+	m                   map[string][]string
+	allGroupIDsErr      error
+	containsGroupIDErrs map[string]error
+	mappedGroupIdsErr   map[string]error
+}
+
+func (tgm *testGroupMapper) AllGroupIDs(ctx context.Context) ([]string, error) {
+	if tgm.allGroupIDsErr != nil {
+		return nil, tgm.allGroupIDsErr
+	}
+	ids := make([]string, 0, len(tgm.m))
+	for id := range tgm.m {
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
+func (tgm *testGroupMapper) ContainsGroupID(ctx context.Context, groupID string) (bool, error) {
+	if err, ok := tgm.containsGroupIDErrs[groupID]; ok {
+		return false, err
+	}
+	_, ok := tgm.m[groupID]
+	return ok, nil
+}
+
+func (tgm *testGroupMapper) MappedGroupIDs(ctx context.Context, groupID string) ([]string, error) {
+	if err, ok := tgm.mappedGroupIdsErr[groupID]; ok {
+		return nil, err
+	}
+	ids, ok := tgm.m[groupID]
+	if !ok {
+		return nil, fmt.Errorf("group %s not mapped", groupID)
+	}
+	return ids, nil
+}
+
+type testUserMapper struct {
+	m                map[string]string
+	mappedUserIDErrs map[string]error
+}
+
+func (tum *testUserMapper) MappedUserID(ctx context.Context, userID string) (string, error) {
+	if err, ok := tum.mappedUserIDErrs[userID]; ok {
+		return "", err
+	}
+	id, ok := tum.m[userID]
+	if !ok {
+		return "", fmt.Errorf("user %s not mapped", userID)
+	}
+	return id, nil
+}


### PR DESCRIPTION
* Add an implementation of the `GroupSyncer` interface for syncing groups that form a many to many relationship.
* Added structs and interfaces for manipulating a group system in a generalized way.