### PR TITLE
Reduce calls

### DIFF
--- a/pkg/groupsync/manytomanysyncer.go
+++ b/pkg/groupsync/manytomanysyncer.go
@@ -36,7 +36,7 @@ type ManyToManySyncer struct {
 	sourceSystem          string
 	targetSystem          string
 	sourceGroupReader     GroupReader
-	targetGroupReadWriter GroupReadWriter
+	targetGroupReadWriter GroupWriter
 	sourceGroupMapper     OneToManyGroupMapper
 	targetGroupMapper     OneToManyGroupMapper
 	userMapper            UserMapper
@@ -46,7 +46,7 @@ type ManyToManySyncer struct {
 func NewManyToManySyncer(
 	sourceSystem, targetSystem string,
 	sourceGroupClient GroupReader,
-	targetGroupClient GroupReadWriter,
+	targetGroupClient GroupWriter,
 	sourceGroupMapper OneToManyGroupMapper,
 	targetGroupMapper OneToManyGroupMapper,
 	userMapper UserMapper,
@@ -219,12 +219,7 @@ func (f *ManyToManySyncer) targetUsers(ctx context.Context, sourceUsers []*User)
 			merr = fmt.Errorf("error mapping source user id %s to target user id: %w", sourceUser.ID, err)
 			continue
 		}
-		targetUser, err := f.targetGroupReadWriter.GetUser(ctx, targetUserID)
-		if err != nil {
-			merr = fmt.Errorf("error fetching user for user id %s: %w", targetUserID, err)
-			continue
-		}
-		targetUsers = append(targetUsers, targetUser)
+		targetUsers = append(targetUsers, &User{ID: targetUserID})
 	}
 	return targetUsers, merr
 }


### PR DESCRIPTION
Remove call to lookup user from target sytem from `ManyToManySyncer`. `ManyToManySyncer` can just pass in the IDs of the users to the target system `GroupWriter` which can decide itself if it needs to lookup any information aside from the ID.

This change will help eliminate unnecessary calls and therefore reduce rate limiting errors. 