### PR TITLE
Refactor `SetMembers`

### DIFF
--- a/pkg/github/teamreadwriter.go
+++ b/pkg/github/teamreadwriter.go
@@ -342,7 +342,7 @@ func (g *TeamReadWriter) removeSubTeamFromTeam(ctx context.Context, client *gith
 		return fmt.Errorf("could not parse group ID %s: %w", groupID, err)
 	}
 	if childOrgID != orgID {
-		return fmt.Errorf("cannot add team from another org as a child team")
+		return fmt.Errorf("cannot remove team from another org as a child team")
 	}
 	if err := removeSubTeam(ctx, client, orgID, teamID, childTeamID); err != nil {
 		return fmt.Errorf("failed to remove child team: %w", err)


### PR DESCRIPTION
Clean up the `SetMembers` function by spliting out the different scenarios (add/remove user/subteam) into their own functions

Add configuration option to enable inviting the user to the org being synced to if they are not already a member.