### PR TITLE
Bugfix - return error in SetMembers for GitHub

### DIFF
--- a/pkg/github/teamreadwriter.go
+++ b/pkg/github/teamreadwriter.go
@@ -351,7 +351,7 @@ func (g *TeamReadWriter) SetMembers(ctx context.Context, groupID string, members
 			}
 		}
 	}
-	return nil
+	return merr
 }
 
 func (g *TeamReadWriter) githubClientForOrg(ctx context.Context, orgID int64) (*github.Client, error) {


### PR DESCRIPTION
We were forgetting to return errors adding/removing team members in `SetMembers`. 