### PR TITLE
feat: create mapper from github to google groups

### DIFF
--- a/pkg/client/mapper_test.go
+++ b/pkg/client/mapper_test.go
@@ -25,7 +25,7 @@ import (
 	tltypes "github.com/abcxyz/team-link/internal"
 )
 
-func TestCreateBidirectionGoogleGroupGitHubMapper(t *testing.T) {
+func TestCreateBidirectionalGoogleGroupGitHubMapper(t *testing.T) {
 	t.Parallel()
 	defaultWritePath := "test.textproto"
 	cases := []struct {
@@ -115,7 +115,7 @@ mappings: [
 			}
 			defer os.Remove(tempFile.Name())
 
-			// Write textprto to temp dir.
+			// Write textproto to temp dir.
 			_, err = tempFile.WriteString(tc.content)
 			if err != nil {
 				t.Fatal("failed to write tempFile: %w", err)


### PR DESCRIPTION
This PR includes:
1. Create `GroupMapper` type for `GoogleGroup->GitHub` and `GitHub->GoogleGroup` mappers.
2. Update Mapper constructor to create both mapper mentioned above.

Kudos to @drevell for pair programming and come up with this clean and elegant solution.