### PR TITLE
feat: complete user cli journey, add github writer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/google/go-github/v61 v61.0.0
 	github.com/xanzy/go-gitlab v0.114.0
+	golang.org/x/oauth2 v0.24.0
 	google.golang.org/api v0.210.0
 	google.golang.org/protobuf v1.35.2
 )
@@ -37,7 +38,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.32.0 // indirect
 	golang.org/x/crypto v0.29.0 // indirect
 	golang.org/x/net v0.31.0 // indirect
-	golang.org/x/oauth2 v0.24.0 // indirect
 	golang.org/x/sys v0.28.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
 	golang.org/x/time v0.8.0 // indirect

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -15,22 +15,16 @@
 package client
 
 import (
-	"context"
-	"fmt"
-
-	tltypes "github.com/abcxyz/team-link/internal"
-	"github.com/abcxyz/team-link/pkg/googlegroups"
-	"github.com/abcxyz/team-link/pkg/groupsync"
+	"github.com/abcxyz/pkg/cli"
+	tlgithub "github.com/abcxyz/team-link/pkg/github"
 )
 
-// NewReader creates a GroupReader base on provided source type.
-func NewReader(ctx context.Context, source string) (groupsync.GroupReader, error) {
-	if source == tltypes.SystemTypeGoogleGroups {
-		r, err := googlegroups.NewReader(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create reader for %s: %w", source, err)
-		}
-		return r, nil
-	}
-	return nil, fmt.Errorf("source type %s not allowd", source)
+// ClientConfig has the specific client
+// config for different systems.
+type ClientConfig struct {
+	GitHub tlgithub.ClientConfig
+}
+
+func (c *ClientConfig) RegisterFlags(set *cli.FlagSet) {
+	c.GitHub.RegisterFlags(set)
 }

--- a/pkg/client/writer.go
+++ b/pkg/client/writer.go
@@ -19,18 +19,18 @@ import (
 	"fmt"
 
 	tltypes "github.com/abcxyz/team-link/internal"
-	"github.com/abcxyz/team-link/pkg/googlegroups"
+	tlgithub "github.com/abcxyz/team-link/pkg/github"
 	"github.com/abcxyz/team-link/pkg/groupsync"
 )
 
-// NewReader creates a GroupReader base on provided source type.
-func NewReader(ctx context.Context, source string) (groupsync.GroupReader, error) {
-	if source == tltypes.SystemTypeGoogleGroups {
-		r, err := googlegroups.NewReader(ctx)
+// NewReadWriter creates a GroupReadWriter base on provided destination type.
+func NewReadWriter(ctx context.Context, destination string, config *ClientConfig) (groupsync.GroupReadWriter, error) {
+	if destination == tltypes.SystemTypeGitHub {
+		readWriter, err := tlgithub.NewGitHubTeamReadWriter(ctx, &config.GitHub)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create reader for %s: %w", source, err)
+			return nil, fmt.Errorf("failed to create ReadWriter for destination system %s: %w", destination, err)
 		}
-		return r, nil
+		return readWriter, nil
 	}
-	return nil, fmt.Errorf("source type %s not allowd", source)
+	return nil, fmt.Errorf("destination type %s not allowed", destination)
 }

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -1,0 +1,88 @@
+// Copyright 2024 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package github
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-github/v61/github"
+	"golang.org/x/oauth2"
+
+	"github.com/abcxyz/pkg/cli"
+)
+
+const DefaultGitHubServerEndpoint = "https://github.com"
+
+// ClientConfig is the config for github client.
+type ClientConfig struct {
+	Endpoint string
+	Token    string
+}
+
+func (c *ClientConfig) RegisterFlags(set *cli.FlagSet) {
+	f := set.NewSection("GITHUB OPTIONS")
+
+	// The priority for parseing the flags are as follows.
+	// It will use the value for toppest priority
+	// 1. Read from input flags.
+	// 2. Read from Envvars.
+	// 3. Use default value.
+	f.StringVar(&cli.StringVar{
+		Name:    "github-server-endpoint",
+		EnvVar:  "GITHUB_SERVER_URL",
+		Target:  &c.Endpoint,
+		Default: DefaultGitHubServerEndpoint,
+		Usage:   `URL for github endpoint, example: "https://github.com"`,
+	})
+
+	f.StringVar(&cli.StringVar{
+		Name:   "github-client-auth-token",
+		Target: &c.Token,
+		Usage:  `Token to authenticate with github`,
+	})
+
+	set.AfterParse(func(merr error) error {
+		// In case user export GITHUB_SERVER_URL to empty string.
+		if c.Endpoint == "" {
+			c.Endpoint = DefaultGitHubServerEndpoint
+		}
+		return nil
+	})
+}
+
+// NewGitHubClient create a github.Client base on ClientConfig.
+func NewGitHubClient(ctx context.Context, c *ClientConfig) (*github.Client, error) {
+	ghc := github.NewClient(oauth2.NewClient(ctx, oauth2.StaticTokenSource(&oauth2.Token{
+		AccessToken: c.Token,
+	})))
+	var err error
+	if c.Endpoint != DefaultGitHubServerEndpoint {
+		if ghc, err = ghc.WithEnterpriseURLs(c.Endpoint, c.Endpoint); err != nil {
+			return nil, fmt.Errorf("failed to create github client with enterprise endpoint %s: %w", c.Endpoint, err)
+		}
+	}
+	return ghc, nil
+}
+
+// NewGitHubTeamReadWriter creates sa new ReadWriter for GitHub.
+func NewGitHubTeamReadWriter(ctx context.Context, c *ClientConfig) (*TeamReadWriter, error) {
+	gts := NewStaticTokenSource(c.Token)
+	rw, err := NewGitHubClient(ctx, c)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GitHubReadWriter: %w", err)
+	}
+	return NewTeamReadWriter(gts, rw), nil
+}

--- a/pkg/github/tokensource.go
+++ b/pkg/github/tokensource.go
@@ -61,3 +61,24 @@ func (s *AppTokenSource) TokenForOrg(ctx context.Context, orgID int64) (string, 
 	}
 	return token, nil
 }
+
+// StaticTokenSource contains token to authenticate with github.
+// This implements OrgTokenSource.
+//
+// If you have a token with all the required permissions, you can use this TokenSource.
+// This is for using github workflows to call tlctl binary thus orgID won't
+// be used.
+// If you intend to have a Credential provider, please use AppTokenSource.
+type StaticTokenSource struct {
+	token string
+}
+
+func (g *StaticTokenSource) TokenForOrg(ctx context.Context, orgID int64) (string, error) {
+	return g.token, nil
+}
+
+func NewStaticTokenSource(token string) *StaticTokenSource {
+	return &StaticTokenSource{
+		token: token,
+	}
+}

--- a/pkg/googlegroups/client.go
+++ b/pkg/googlegroups/client.go
@@ -1,0 +1,45 @@
+// Copyright 2024 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlegroups
+
+import (
+	"context"
+	"fmt"
+
+	admin "google.golang.org/api/admin/directory/v1"
+	"google.golang.org/api/cloudidentity/v1"
+
+	"github.com/abcxyz/team-link/pkg/groupsync"
+)
+
+// NewReader creates a group reader for GoogleGroups.
+// For now we will only support read auth token from default
+// environment variable GOOGLE_APPLICATION_CREDENTIALS.
+// See the follow link for more details
+// https://cloud.google.com/docs/authentication/application-default-credentials
+//
+// You use `gcloud auth application-default login` or use
+// google-gihub-actions/auth to have the credentials written to this env var.
+func NewReader(ctx context.Context) (groupsync.GroupReader, error) {
+	cs, err := cloudidentity.NewService(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cloudidentity service: %w", err)
+	}
+	as, err := admin.NewService(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create admin service: %w", err)
+	}
+	return NewGroupReader(cs, as), nil
+}


### PR DESCRIPTION
Example cli and output:

This example is to sync google group with a team in my own org, it's expecting `gjonathanhong` and `kevya-google` be removed.

```
> tlctl sync run -source GOOGLEGROUPS -d GITHUB -gc 'a.textproto' -uc 'b.textproto' -github-client-auth-token 'my-token'

{"time":"2024-12-12T21:39:40.748852932Z","severity":"INFO","message":"starting sync","source_group_id":"groups/04f1mdlm2alv5ca"}
{"time":"2024-12-12T21:39:40.748958629Z","severity":"INFO","message":"found the following target group IDs to sync","source_group_id":"groups/04f1mdlm2alv5ca","target_group_ids":["145597256:11735575"]}
{"time":"2024-12-12T21:39:40.748972513Z","severity":"INFO","message":"syncing target group ID","target_group_id":"145597256:11735575"}
{"time":"2024-12-12T21:39:40.748978589Z","severity":"INFO","message":"found source group ID(s) for target Group ID","target_group_id":"145597256:11735575","source_group_ids":["groups/04f1mdlm2alv5ca"]}
{"time":"2024-12-12T21:39:41.056409241Z","severity":"INFO","message":"found descendant(s) for source group ID(s)","source_group_ids":["groups/04f1mdlm2alv5ca"],"source_user_ids":["qinhang@tycho.joonix.net"]}
{"time":"2024-12-12T21:39:41.056513204Z","severity":"INFO","message":"mapped source users to target users","source_user_ids":["qinhang@tycho.joonix.net"],"target_user_ids":["sailorlqh"]}
{"time":"2024-12-12T21:39:41.056534694Z","severity":"INFO","message":"setting target group ID members to target users","target_group_id":"145597256:11735575","target_user_ids":["sailorlqh"]}
{"time":"2024-12-12T21:39:41.056555495Z","severity":"INFO","message":"fetching members for team","team_id":"145597256:11735575"}
{"time":"2024-12-12T21:39:41.48332866Z","severity":"INFO","message":"current team members","team_id":"145597256:11735575","current_member_ids":["gjonathanhong","kevya-google","sailorlqh"]}
{"time":"2024-12-12T21:39:41.483375018Z","severity":"INFO","message":"authoritative team members","team_id":"145597256:11735575","authoritative_member_ids":["sailorlqh"]}
{"time":"2024-12-12T21:39:41.483385867Z","severity":"INFO","message":"members to add","team_id":"145597256:11735575","add_member_ids":[]}
{"time":"2024-12-12T21:39:41.483394169Z","severity":"INFO","message":"members to remove","team_id":"145597256:11735575","remove_member_ids":["gjonathanhong","kevya-google"]}
```

If you look at the last line in the log, you can see the result matches our expectation.