### PR TITLE
fix: update minty to only allow main branch trigger

### DIFF
--- a/.github/minty.yaml
+++ b/.github/minty.yaml
@@ -4,7 +4,8 @@ rule:
   if: |-
     assertion.iss == issuers.github &&
     assertion.repository_owner_id == '93787867' &&
-    assertion.repository_id == '767194578'
+    assertion.repository_id == '767194578'&&
+    assertion.ref == 'refs/heads/main'
 
 scope:
   teamlink:

--- a/.github/minty.yaml
+++ b/.github/minty.yaml
@@ -4,7 +4,7 @@ rule:
   if: |-
     assertion.iss == issuers.github &&
     assertion.repository_owner_id == '93787867' &&
-    assertion.repository_id == '767194578'&&
+    assertion.repository_id == '767194578' &&
     assertion.ref == 'refs/heads/main'
 
 scope:


### PR DESCRIPTION
Follow up for https://github.com/abcxyz/team-link/pull/97