### PR TITLE
Update sync workflow to be only manual trigger

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -15,13 +15,7 @@
 name: 'Sync GoogleGroups to GitHub Membership'
 
 on:
-  push:
   workflow_dispatch:
-    inputs:
-      destinationToken:
-        type: 'string'
-        description: 'token for your target system'
-        required: true
 
 permissions:
   contents: 'read'


### PR DESCRIPTION
We can also make this a cron job, but so far we are not actively using this, we can add this cron job thing later if needed.