### PR TITLE
Update minty config to allow calling on non-main branch

### DIFF
--- a/.github/minty.yaml
+++ b/.github/minty.yaml
@@ -4,8 +4,7 @@ rule:
   if: |-
     assertion.iss == issuers.github &&
     assertion.repository_owner_id == '93787867' &&
-    assertion.repository_id == '767194578' &&
-    assertion.ref == 'refs/heads/main'
+    assertion.repository_id == '767194578'
 
 scope:
   teamlink:


### PR DESCRIPTION
Changing minty config to allow token request on non-main branch so I can test on getting SSO identity during development