### PR TITLE
update minty rule to allow dev

### DIFF
--- a/.github/minty.yaml
+++ b/.github/minty.yaml
@@ -4,15 +4,27 @@ rule:
   if: |-
     assertion.iss == issuers.github &&
     assertion.repository_owner_id == '93787867' &&
-    assertion.repository_id == '767194578' &&
-    ( assertion.ref == 'refs/heads/main' || assertion.ref == 'refs/heads/sailorlqh/sso_poc' )
+    assertion.repository_id == '767194578'
 
 scope:
   teamlink:
     rule:
       if: |-
-        assertion.workflow_ref.startsWith("abcxyz/team-link/.github/workflows/sync.yml")
+        assertion.workflow_ref.startsWith("abcxyz/team-link/.github/workflows/sync.yml") &&
+        assertion.ref == 'refs/heads/main'
     repositories:
       - 'team-link'
     permissions:
       members: 'write'
+      orgnization: 'read'
+  #TODO: remove this rule once the github sso development is done.
+  teamlink-dev:
+    rule:
+      if: |-
+        assertion.workflow_ref.startsWith("abcxyz/team-link/.github/workflows/sync.yml") &&
+        assertion.ref == 'refs/heads/sailorlqh/sso_poc'
+    repositories:
+      - 'team-link'
+    permissions:
+      members: 'write'
+      orgnization: 'read'

--- a/.github/minty.yaml
+++ b/.github/minty.yaml
@@ -5,7 +5,7 @@ rule:
     assertion.iss == issuers.github &&
     assertion.repository_owner_id == '93787867' &&
     assertion.repository_id == '767194578' &&
-    ( assertion.ref == 'refs/heads/main' || assertion.ref == 'refs/heads/sso_poc' )
+    ( assertion.ref == 'refs/heads/main' || assertion.ref == 'refs/heads/sailorlqh/sso_poc' )
 
 scope:
   teamlink:

--- a/.github/minty.yaml
+++ b/.github/minty.yaml
@@ -5,7 +5,7 @@ rule:
     assertion.iss == issuers.github &&
     assertion.repository_owner_id == '93787867' &&
     assertion.repository_id == '767194578' &&
-    assertion.ref == 'refs/heads/main'
+    ( assertion.ref == 'refs/heads/main' || assertion.ref == 'refs/heads/sso_poc' )
 
 scope:
   teamlink:

--- a/.github/minty.yaml
+++ b/.github/minty.yaml
@@ -17,7 +17,7 @@ scope:
     permissions:
       members: 'write'
       orgnization: 'read'
-  #TODO: remove this rule once the github sso development is done.
+  # TODO: remove this rule once the github sso development is done.
   teamlink-dev:
     rule:
       if: |-


### PR DESCRIPTION
Update minty rule to allow development on  branch`sailorlqh/sso_poc` to be able to request tokens.
The `sso_poc` branch will be used to test graphQL to obtain user SAML identities.