### PR TITLE
fix: fix minty permissions

### DIFF
--- a/.github/minty.yaml
+++ b/.github/minty.yaml
@@ -27,4 +27,3 @@ scope:
       - 'team-link'
     permissions:
       members: 'write'
-      orgnization: 'read'


### PR DESCRIPTION
According to this link: https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#create-an-installation-access-token-for-an-app.

`member: write` permission gives us permission to sync members and read org members.
Also I am so dumb so I made a typo in previous commit 😭 

<img width="458" alt="image" src="https://github.com/user-attachments/assets/6e0f6b47-2fdf-46f9-adde-bdd0de55242c" />
