### PR TITLE
update minty to allow create tag

### DIFF
--- a/.github/minty.yaml
+++ b/.github/minty.yaml
@@ -26,3 +26,13 @@ scope:
       - 'team-link'
     permissions:
       members: 'write'
+  create-tag:
+    rule:
+      if: |-
+        assertion.job_workflow_ref == "abcxyz/pkg/.github/workflows/create-tag.yml@refs/heads/main" &&
+        assertion.workflow_ref.startsWith("abcxyz/team-link/.github/workflows/create-tag.yml") &&
+        assertion.event_name == 'workflow_dispatch'
+    repositories:
+      - 'team-link'
+    permissions:
+      contents: 'write'


### PR DESCRIPTION
`create-tag` workflow will be included in the followup PR