### PR TITLE
fix: add workflow_call trigger to ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ on:
     branches:
       - 'main'
       - 'release/**/*'
+  workflow_call:
 
 concurrency:
   group: '${{ github.workflow }}-${{ github.event_name}}-${{ github.head_ref || github.ref }}'


### PR DESCRIPTION
This allows release workflow to call ci workflow.