### PR TITLE
feat: add SSO support for github

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,8 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/posener/complete/v2 v2.1.0 // indirect
 	github.com/posener/script v1.2.0 // indirect
+	github.com/shurcooL/githubv4 v0.0.0-20240727222349-48295856cce7 // indirect
+	github.com/shurcooL/graphql v0.0.0-20230722043721-ed46e5a46466 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.59.0 // indirect
 	go.opentelemetry.io/otel v1.34.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/abcxyz/pkg v1.4.0
 	github.com/google/go-cmp v0.6.0
 	github.com/google/go-github/v61 v61.0.0
+	github.com/shurcooL/githubv4 v0.0.0-20240727222349-48295856cce7
 	gitlab.com/gitlab-org/api/client-go v0.122.0
 	golang.org/x/oauth2 v0.26.0
 	google.golang.org/api v0.221.0
@@ -32,7 +33,6 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/posener/complete/v2 v2.1.0 // indirect
 	github.com/posener/script v1.2.0 // indirect
-	github.com/shurcooL/githubv4 v0.0.0-20240727222349-48295856cce7 // indirect
 	github.com/shurcooL/graphql v0.0.0-20230722043721-ed46e5a46466 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.59.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,10 @@ github.com/posener/complete/v2 v2.1.0 h1:IpAWxMyiJ6zDSoq+QmEBF0thpOramC0kYuEFBTc
 github.com/posener/complete/v2 v2.1.0/go.mod h1:AkzsSVGx4ysH/4OhZf57dr4yszGXgFmXsP/VNwlaW7U=
 github.com/posener/script v1.2.0 h1:DrZz0qFT8lCLkYNi1PleLDANFnKxJ2VmlNPJbAkVLsE=
 github.com/posener/script v1.2.0/go.mod h1:s4sVvRXtdc/1aK6otTSeW2BVXndO8MsoOVUwK74zcg4=
+github.com/shurcooL/githubv4 v0.0.0-20240727222349-48295856cce7 h1:cYCy18SHPKRkvclm+pWm1Lk4YrREb4IOIb/YdFO0p2M=
+github.com/shurcooL/githubv4 v0.0.0-20240727222349-48295856cce7/go.mod h1:zqMwyHmnN/eDOZOdiTohqIUKUrTFX62PNlu7IJdu0q8=
+github.com/shurcooL/graphql v0.0.0-20230722043721-ed46e5a46466 h1:17JxqqJY66GmZVHkmAsGEkcIu0oCe3AM420QDgGwZx0=
+github.com/shurcooL/graphql v0.0.0-20230722043721-ed46e5a46466/go.mod h1:9dIRpgIY7hVhoqfe0/FcYp0bpInZaT7dc3BYOprrIUE=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 gitlab.com/gitlab-org/api/client-go v0.122.0 h1:Nog85APtgquS+HHkMkP4DiZ6lXlUZYhQKqguS4OJYNM=

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -36,5 +36,9 @@ func NewTeamReadWriterWithStaticTokenSource(ctx context.Context, s *StaticTokenS
 			return nil, fmt.Errorf("failed to create github client with enterprise endpoint %s: %w", endpoint, err)
 		}
 	}
-	return NewTeamReadWriter(s, ghc, orgTeamSSORequired), nil
+	samlIdentities, err := GetAllOrgsSamlIdentities(ctx, s, endpoint, ghc, orgTeamSSORequired)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get org saml identities: %w", err)
+	}
+	return NewTeamReadWriter(s, ghc, orgTeamSSORequired, samlIdentities), nil
 }

--- a/pkg/github/sso.go
+++ b/pkg/github/sso.go
@@ -1,0 +1,92 @@
+package github
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-github/v61/github"
+	"github.com/shurcooL/githubv4"
+	"golang.org/x/oauth2"
+)
+
+// GetAllOrgsSamlIdentities get all users that have saml identities from each organization.
+func GetAllOrgsSamlIdentities(ctx context.Context, s *StaticTokenSource, endpoint string, ghc *github.Client, orgTeamSSORequired map[int64]map[int64]bool) (map[int64]map[string]struct{}, error) {
+	httpClient := oauth2.NewClient(ctx, oauth2.StaticTokenSource(&oauth2.Token{
+		AccessToken: s.GetStaticToken(),
+	}))
+
+	var gqlClient *githubv4.Client
+	if endpoint != DefaultGitHubEndpointURL {
+		gqlClient = githubv4.NewEnterpriseClient(endpoint, httpClient)
+	} else {
+		gqlClient = githubv4.NewClient(httpClient)
+	}
+
+	orgsSamlMap := make(map[int64]map[string]struct{})
+
+	for id := range orgTeamSSORequired {
+		// GraphQL only supports query saml using orgLogin.
+		// We only know org ID, thus we need to get orgLogin info
+		// before we run graphQL to get saml info.
+		org, _, err := ghc.Organizations.GetByID(ctx, id)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get organization with id %d: %w", id, err)
+		}
+		res, err := GetOrgSamlIdentities(ctx, gqlClient, *org.Login)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get SAML info for org %s (org id: %d)", *org.Login, id)
+		}
+		orgsSamlMap[id] = res
+	}
+	return orgsSamlMap, nil
+}
+
+// GetOrgSamlIdentities get all users with saml identities from the given org.
+func GetOrgSamlIdentities(ctx context.Context, client *githubv4.Client, orglogin string) (map[string]struct{}, error) {
+	var samlQuery struct {
+		Organization struct {
+			SAMLIdentityProvider struct {
+				ExternalIdentities struct {
+					Edges []struct {
+						Node struct {
+							User struct {
+								Login string
+							}
+							SAMLIdentity struct {
+								NameID string
+							}
+						}
+					}
+					PageInfo struct {
+						EndCursor   githubv4.String
+						HasNextPage bool
+					}
+				} `graphql:"externalIdentities(first: 100, after: $cursor)"`
+			}
+		} `graphql:"organization(login: $org)"`
+	}
+	vars := map[string]any{
+		"org":    githubv4.String(orglogin),
+		"cursor": (*githubv4.String)(nil),
+	}
+
+	orgSamlMembers := make(map[string]struct{})
+
+	for {
+		if err := client.Query(ctx, &samlQuery, vars); err != nil {
+			return nil, fmt.Errorf("executing GraphQL query: %w", err)
+		}
+		// We don't need to save the external saml email nor check the externalSAML email domain,
+		// this is because the above graphQL query only returns all users with external saml identitys
+		// in the given org. And each github org can only have sso.
+		for _, edge := range samlQuery.Organization.SAMLIdentityProvider.ExternalIdentities.Edges {
+			orgSamlMembers[edge.Node.User.Login] = struct{}{}
+		}
+		if !samlQuery.Organization.SAMLIdentityProvider.ExternalIdentities.PageInfo.HasNextPage {
+			break
+		}
+		vars["cursor"] = githubv4.NewString(samlQuery.Organization.SAMLIdentityProvider.ExternalIdentities.PageInfo.EndCursor)
+	}
+
+	return orgSamlMembers, nil
+}

--- a/pkg/github/sso.go
+++ b/pkg/github/sso.go
@@ -10,6 +10,8 @@ import (
 )
 
 // GetAllOrgsSamlIdentities get all users that have saml identities from each organization.
+// This function returns a map with each orgID as key and a set of users with samkIdentities
+// as value.
 func GetAllOrgsSamlIdentities(ctx context.Context, s *StaticTokenSource, endpoint string, ghc *github.Client, orgTeamSSORequired map[int64]map[int64]bool) (map[int64]map[string]struct{}, error) {
 	httpClient := oauth2.NewClient(ctx, oauth2.StaticTokenSource(&oauth2.Token{
 		AccessToken: s.GetStaticToken(),

--- a/pkg/github/sso.go
+++ b/pkg/github/sso.go
@@ -1,3 +1,17 @@
+// Copyright 2024 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package github
 
 import (

--- a/pkg/github/teamreadwriter.go
+++ b/pkg/github/teamreadwriter.go
@@ -381,7 +381,7 @@ func (g *TeamReadWriter) addUserToTeam(ctx context.Context, client *github.Clien
 		membershipOpt := &github.TeamAddTeamMembershipOptions{Role: "member"}
 		// Conditions below checks if the given team requires saml
 		// and if the user has external saml identities.
-		// The map keys existance check is not really necessary as it's computed
+		// The map keys existence check is not really necessary as it's computed
 		// by the textprotos, they are here just to make the code safer.
 		if teamSSO, ok := g.orgTeamSSORequired[orgID]; ok {
 			if required, ok := teamSSO[teamID]; ok && required {

--- a/pkg/github/teamreadwriter_test.go
+++ b/pkg/github/teamreadwriter_test.go
@@ -123,7 +123,7 @@ func TestTeamReadWriter_GetGroup(t *testing.T) {
 
 			client := githubClient(server)
 
-			groupRW := NewTeamReadWriter(tc.tokenSource, client, nil)
+			groupRW := NewTeamReadWriter(tc.tokenSource, client, nil, nil)
 
 			got, err := groupRW.GetGroup(ctx, tc.groupID)
 			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
@@ -500,7 +500,7 @@ func TestTeamReadWriter_GetMembers(t *testing.T) {
 
 			client := githubClient(server)
 
-			groupRW := NewTeamReadWriter(tc.tokenSource, client, nil, tc.opts...)
+			groupRW := NewTeamReadWriter(tc.tokenSource, client, nil, nil, tc.opts...)
 
 			got, err := groupRW.GetMembers(ctx, tc.groupID)
 			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
@@ -749,7 +749,7 @@ func TestTeamReadWriter_GetDescendants(t *testing.T) {
 
 			client := githubClient(server)
 
-			groupRW := NewTeamReadWriter(tc.tokenSource, client, nil)
+			groupRW := NewTeamReadWriter(tc.tokenSource, client, nil, nil)
 
 			got, err := groupRW.Descendants(ctx, tc.groupID)
 			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
@@ -829,7 +829,7 @@ func TestTeamReadWriter_GetUser(t *testing.T) {
 
 			client := githubClient(server)
 
-			groupRW := NewTeamReadWriter(tc.tokenSource, client, nil)
+			groupRW := NewTeamReadWriter(tc.tokenSource, client, nil, nil)
 
 			got, err := groupRW.GetUser(ctx, tc.userID)
 			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
@@ -2162,7 +2162,7 @@ func TestTeamReadWriter_SetMembers(t *testing.T) {
 
 			client := githubClient(server)
 
-			groupRW := NewTeamReadWriter(tc.tokenSource, client, nil, tc.opts...)
+			groupRW := NewTeamReadWriter(tc.tokenSource, client, nil, nil, tc.opts...)
 
 			err := groupRW.SetMembers(ctx, tc.groupID, tc.inputMembers)
 			if diff := testutil.DiffErrString(err, tc.wantSetErr); diff != "" {


### PR DESCRIPTION
This PR implement feature of checking if user has SSO enabled before adding the user to github group.

The procedure of doing this is:
1. Use GraphQL to Get all SAML identities within the given org.
2. When adding users to github team, check if the given team requires SSO and if this user has saml identity in the organization.

This feature is tested in my test org with mapping a same google group to two different github team with one requires SSO and the other one don't.

Team that requires SSO only added member with saml identity. While the doesn't require SSO added all team member.