### PR TITLE
fix: refactor SSO functions to accept httpclient

### DIFF
--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -36,7 +36,11 @@ func NewTeamReadWriterWithStaticTokenSource(ctx context.Context, s *StaticTokenS
 			return nil, fmt.Errorf("failed to create github client with enterprise endpoint %s: %w", endpoint, err)
 		}
 	}
-	samlIdentities, err := GetAllOrgsSamlIdentities(ctx, s, endpoint, ghc, orgTeamSSORequired)
+
+	httpClient := oauth2.NewClient(ctx, oauth2.StaticTokenSource(&oauth2.Token{
+		AccessToken: s.GetStaticToken(),
+	}))
+	samlIdentities, err := GetAllOrgsSamlIdentities(ctx, httpClient, endpoint, ghc, orgTeamSSORequired)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get org saml identities: %w", err)
 	}

--- a/pkg/github/sso.go
+++ b/pkg/github/sso.go
@@ -17,20 +17,16 @@ package github
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/google/go-github/v61/github"
 	"github.com/shurcooL/githubv4"
-	"golang.org/x/oauth2"
 )
 
 // GetAllOrgsSamlIdentities get all users that have saml identities from each organization.
 // This function returns a map with each orgID as key and a set of users with samkIdentities
 // as value.
-func GetAllOrgsSamlIdentities(ctx context.Context, s *StaticTokenSource, endpoint string, ghc *github.Client, orgTeamSSORequired map[int64]map[int64]bool) (map[int64]map[string]struct{}, error) {
-	httpClient := oauth2.NewClient(ctx, oauth2.StaticTokenSource(&oauth2.Token{
-		AccessToken: s.GetStaticToken(),
-	}))
-
+func GetAllOrgsSamlIdentities(ctx context.Context, httpClient *http.Client, endpoint string, ghc *github.Client, orgTeamSSORequired map[int64]map[int64]bool) (map[int64]map[string]struct{}, error) {
 	var gqlClient *githubv4.Client
 	if endpoint != DefaultGitHubEndpointURL {
 		gqlClient = githubv4.NewEnterpriseClient(endpoint, httpClient)


### PR DESCRIPTION
Change GetAllOrgsSamlIdentities to take a httpclient instead of a staticTokenSource makes the caller to be more versatile instead of bounded to use staticTokenSource