### PR TITLE
Refactor to use cache for SAML identity

### DIFF
--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 
 	"github.com/google/go-github/v61/github"
-	"github.com/shurcooL/githubv4"
 	"golang.org/x/oauth2"
 )
 
@@ -38,16 +37,5 @@ func NewTeamReadWriterWithStaticTokenSource(ctx context.Context, s *StaticTokenS
 		}
 	}
 
-	httpClient := oauth2.NewClient(ctx, oauth2.StaticTokenSource(&oauth2.Token{
-		AccessToken: s.GetStaticToken(),
-	}))
-
-	var gqlClient *githubv4.Client
-	if endpoint != DefaultGitHubEndpointURL {
-		gqlClient = githubv4.NewEnterpriseClient(endpoint, httpClient)
-	} else {
-		gqlClient = githubv4.NewClient(httpClient)
-	}
-
-	return NewTeamReadWriter(s, ghc, gqlClient, orgTeamSSORequired), nil
+	return NewTeamReadWriter(s, ghc, endpoint, orgTeamSSORequired), nil
 }

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -42,7 +42,7 @@ func NewTeamReadWriterWithStaticTokenSource(ctx context.Context, s *StaticTokenS
 }
 
 // CreateGraphQLClientWithToken creates a graphQL client with a static token.
-func CreateGraphQLClientWithToken(ctx context.Context, token string, endpoint string) *githubv4.Client {
+func CreateGraphQLClientWithToken(ctx context.Context, token, endpoint string) *githubv4.Client {
 	httpClient := oauth2.NewClient(ctx, oauth2.StaticTokenSource(&oauth2.Token{
 		AccessToken: token,
 	}))

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/google/go-github/v61/github"
+	"github.com/shurcooL/githubv4"
 	"golang.org/x/oauth2"
 )
 
@@ -38,4 +39,18 @@ func NewTeamReadWriterWithStaticTokenSource(ctx context.Context, s *StaticTokenS
 	}
 
 	return NewTeamReadWriter(s, ghc, endpoint, orgTeamSSORequired), nil
+}
+
+// CreateGraphQLClientWithToken creates a graphQL client with a static token.
+func CreateGraphQLClientWithToken(ctx context.Context, token string, endpoint string) *githubv4.Client {
+	httpClient := oauth2.NewClient(ctx, oauth2.StaticTokenSource(&oauth2.Token{
+		AccessToken: token,
+	}))
+	var gqlClient *githubv4.Client
+	if endpoint != DefaultGitHubEndpointURL {
+		gqlClient = githubv4.NewEnterpriseClient(endpoint, httpClient)
+	} else {
+		gqlClient = githubv4.NewClient(httpClient)
+	}
+	return gqlClient
 }

--- a/pkg/github/sso.go
+++ b/pkg/github/sso.go
@@ -53,6 +53,20 @@ func GetAllOrgsSamlIdentities(ctx context.Context, httpClient *http.Client, endp
 	return orgsSamlMap, nil
 }
 
+// GetOrgSamlIdentitiesByOrgID get saml identities for the github org.
+// The return is a map with users have external saml identity attached.
+func GetOrgSamlIdentitiesByOrgID(ctx context.Context, ghc *github.Client, graphqlClient *githubv4.Client, orgID int64) (map[string]struct{}, error) {
+	org, _, err := ghc.Organizations.GetByID(ctx, orgID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get organization with id %d: %w", orgID, err)
+	}
+	res, err := GetOrgSamlIdentities(ctx, graphqlClient, *org.Login)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get SAML info for org %s (org id: %d)", *org.Login, orgID)
+	}
+	return res, nil
+}
+
 // GetOrgSamlIdentities get all users with saml identities from the given org.
 func GetOrgSamlIdentities(ctx context.Context, client *githubv4.Client, orglogin string) (map[string]struct{}, error) {
 	var samlQuery struct {

--- a/pkg/github/sso.go
+++ b/pkg/github/sso.go
@@ -55,14 +55,14 @@ func GetAllOrgsSamlIdentities(ctx context.Context, httpClient *http.Client, endp
 
 // GetOrgSamlIdentitiesByOrgID get saml identities for the github org.
 // The return is a map with users have external saml identity attached.
-func GetOrgSamlIdentitiesByOrgID(ctx context.Context, ghc *github.Client, graphqlClient *githubv4.Client, orgID int64) (map[string]struct{}, error) {
+func GetOrgSamlIdentitiesByOrgID(ctx context.Context, ghc *github.Client, gqc *githubv4.Client, orgID int64) (map[string]struct{}, error) {
 	org, _, err := ghc.Organizations.GetByID(ctx, orgID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get organization with id %d: %w", orgID, err)
 	}
-	res, err := GetOrgSamlIdentities(ctx, graphqlClient, *org.Login)
+	res, err := GetOrgSamlIdentities(ctx, gqc, *org.Login)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get SAML info for org %s (org id: %d)", *org.Login, orgID)
+		return nil, fmt.Errorf("failed to get SAML info for org %s (org id: %d): %w", *org.Login, orgID, err)
 	}
 	return res, nil
 }

--- a/pkg/github/teamreadwriter.go
+++ b/pkg/github/teamreadwriter.go
@@ -107,7 +107,7 @@ type TeamReadWriter struct {
 // will be considered as members of a team. By default, TeamReadWriter does not attempt
 // to add users to an org if they are not already members. This can be enabled by
 // WithInviteToOrgIfNotAMember option.
-// The provided orgTeamSSORequired will be used to verify if a team requires user to have
+// OrgTeamSSORequired will be used to verify if a team requires user to have
 // sso enabled to sync memberships. If orgTeamSSORequired[org][team] is not found, we will
 // default the value to false.
 func NewTeamReadWriter(orgTokenSource OrgTokenSource, client *github.Client, endpoint string, orgTeamSSORequired map[int64]map[int64]bool, opts ...Opt) *TeamReadWriter {

--- a/pkg/github/teamreadwriter.go
+++ b/pkg/github/teamreadwriter.go
@@ -390,14 +390,6 @@ func (g *TeamReadWriter) githubClientForOrg(ctx context.Context, orgID int64) (*
 	return g.client.WithAuthToken(token), nil
 }
 
-func (g *TeamReadWriter) githubGraphQLClientForOrg(ctx context.Context, orgID int64) (*githubv4.Client, error) {
-	_, err := g.orgTokenSource.TokenForOrg(ctx, orgID)
-	if err != nil {
-		return nil, nil
-	}
-	return nil, nil
-}
-
 func (g *TeamReadWriter) addUserToTeam(ctx context.Context, client *github.Client, orgID, teamID int64, userID string) error {
 	logger := logging.FromContext(ctx)
 	orgIDStr := strconv.FormatInt(orgID, 10)
@@ -417,7 +409,7 @@ func (g *TeamReadWriter) addUserToTeam(ctx context.Context, client *github.Clien
 				if err != nil {
 					return fmt.Errorf("failed to get saml identity: %w", err)
 				}
-				if _, ok := saml[userID]; ok {
+				if _, ok := saml[userID]; !ok {
 					logger.WarnContext(ctx, "github user was not added to github group due to group sso requirement",
 						"user", userID,
 						"team", teamID)

--- a/pkg/github/teamreadwriter.go
+++ b/pkg/github/teamreadwriter.go
@@ -282,7 +282,7 @@ func (g *TeamReadWriter) getGitHubUser(ctx context.Context, client *github.Clien
 
 // GetGitHubOrgSaml gets the saml identities for the github org.
 // If the saml for the given orgID is expired in cache or does not exisit,
-// it will retreive the newest saml identitiy information.
+// it will retrieve the newest saml identitiy information.
 func (g *TeamReadWriter) GetGitHubOrgSaml(ctx context.Context, orgID int64) (map[string]struct{}, error) {
 	orgIDStr := strconv.FormatInt(orgID, 10)
 	if orgSaml, ok := g.orgSamlIdentitiesCache.Lookup(orgIDStr); ok {
@@ -296,7 +296,7 @@ func (g *TeamReadWriter) GetGitHubOrgSaml(ctx context.Context, orgID int64) (map
 	}
 	saml, err := GetOrgSamlIdentitiesByOrgID(ctx, g.client, gqlClient, orgID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch org saml identities :w", err)
+		return nil, fmt.Errorf("failed to fetch org saml identities: %w", err)
 	}
 	g.orgSamlIdentitiesCache.Set(orgIDStr, saml)
 	return saml, nil

--- a/pkg/github/teamreadwriter.go
+++ b/pkg/github/teamreadwriter.go
@@ -400,6 +400,12 @@ func (g *TeamReadWriter) graphqlClientForOrg(ctx context.Context, orgID int64, e
 	if err != nil {
 		return nil, fmt.Errorf("failed to get github token: %w", err)
 	}
+	// GraphQL library doesn't support `WithAuthToken()` feature,
+	// instead it expects the provided http client to handle authentications,
+	// therefore, everytime graphql client is needed, we need to use the token
+	// to create a new http client.
+	// Some users are using teamlink as a service, this way the graphQL can still
+	// work if the token rotated when service is running.
 	httpClient := oauth2.NewClient(ctx, oauth2.StaticTokenSource(&oauth2.Token{
 		AccessToken: token,
 	}))

--- a/pkg/github/teamreadwriter.go
+++ b/pkg/github/teamreadwriter.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/google/go-github/v61/github"
+	"github.com/shurcooL/githubv4"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/abcxyz/pkg/cache"
@@ -88,13 +89,14 @@ func WithInviteToOrgIfNotAMember() Opt {
 type TeamReadWriter struct {
 	orgTokenSource          OrgTokenSource
 	client                  *github.Client
+	graphqlClient           *githubv4.Client
 	userCache               *cache.Cache[*github.User]
 	teamCache               *cache.Cache[*github.Team]
 	orgMembershipCache      *cache.Cache[bool]
 	includeSubTeams         bool
 	inviteToOrgIfNotAMember bool
 	orgTeamSSORequired      map[int64]map[int64]bool
-	samlIdentities          map[int64]map[string]struct{}
+	orgSamlIdentitiesCache  *cache.Cache[map[string]struct{}]
 }
 
 // NewTeamReadWriter creates a new TeamReadWriter. By default, TeamReadWriter considers
@@ -107,7 +109,7 @@ type TeamReadWriter struct {
 // The provided orgTeamSSORequired will be used to verify if a team requires user to have
 // sso enabled to sync memberships. If orgTeamSSORequired[org][team] is not found, we will
 // default the value to false.
-func NewTeamReadWriter(orgTokenSource OrgTokenSource, client *github.Client, orgTeamSSORequired map[int64]map[int64]bool, samlIdentities map[int64]map[string]struct{}, opts ...Opt) *TeamReadWriter {
+func NewTeamReadWriter(orgTokenSource OrgTokenSource, client *github.Client, graphqlClient *githubv4.Client, orgTeamSSORequired map[int64]map[int64]bool, opts ...Opt) *TeamReadWriter {
 	config := &Config{
 		includeSubTeams:         true,
 		inviteToOrgIfNotAMember: false,
@@ -119,15 +121,15 @@ func NewTeamReadWriter(orgTokenSource OrgTokenSource, client *github.Client, org
 	t := &TeamReadWriter{
 		orgTokenSource:          orgTokenSource,
 		client:                  client,
+		graphqlClient:           graphqlClient,
 		includeSubTeams:         config.includeSubTeams,
 		inviteToOrgIfNotAMember: config.inviteToOrgIfNotAMember,
 		userCache:               cache.New[*github.User](config.cacheDuration),
 		teamCache:               cache.New[*github.Team](config.cacheDuration),
 		orgMembershipCache:      cache.New[bool](config.cacheDuration),
 		orgTeamSSORequired:      orgTeamSSORequired,
-		samlIdentities:          samlIdentities,
+		orgSamlIdentitiesCache:  cache.New[map[string]struct{}](config.cacheDuration),
 	}
-	// TODO: Obtain and retrieve Org User's SAML info.
 	return t
 }
 
@@ -277,6 +279,24 @@ func (g *TeamReadWriter) getGitHubUser(ctx context.Context, client *github.Clien
 	return user, nil
 }
 
+// GetGitHubOrgSaml gets the saml identities for the github org.
+// If the saml for the given orgID is expired in cache or does not exisit,
+// it will retreive the newest saml identitiy information.
+func (g *TeamReadWriter) GetGitHubOrgSaml(ctx context.Context, orgID int64) (map[string]struct{}, error) {
+	orgIDStr := strconv.FormatInt(orgID, 10)
+	if orgSaml, ok := g.orgSamlIdentitiesCache.Lookup(orgIDStr); ok {
+		return orgSaml, nil
+	}
+	logger := logging.FromContext(ctx)
+	logger.InfoContext(ctx, "fetching org saml identities", "org_id", orgID)
+	res, err := GetOrgSamlIdentitiesByOrgID(ctx, g.client, g.graphqlClient, orgID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch org saml identities :w", err)
+	}
+	g.orgSamlIdentitiesCache.Set(orgIDStr, res)
+	return res, nil
+}
+
 // SetMembers replaces the members of the GitHub team with the given ID with the given members.
 // The ID must be of the form 'orgID:teamID'. Any members of the GitHub team not found in the given members list
 // will be removed. Likewise, any members of the given list that are not currently members of the team will be added.
@@ -370,6 +390,14 @@ func (g *TeamReadWriter) githubClientForOrg(ctx context.Context, orgID int64) (*
 	return g.client.WithAuthToken(token), nil
 }
 
+func (g *TeamReadWriter) githubGraphQLClientForOrg(ctx context.Context, orgID int64) (*githubv4.Client, error) {
+	_, err := g.orgTokenSource.TokenForOrg(ctx, orgID)
+	if err != nil {
+		return nil, nil
+	}
+	return nil, nil
+}
+
 func (g *TeamReadWriter) addUserToTeam(ctx context.Context, client *github.Client, orgID, teamID int64, userID string) error {
 	logger := logging.FromContext(ctx)
 	orgIDStr := strconv.FormatInt(orgID, 10)
@@ -385,13 +413,15 @@ func (g *TeamReadWriter) addUserToTeam(ctx context.Context, client *github.Clien
 		// by the textprotos, they are here just to make the code safer.
 		if teamSSO, ok := g.orgTeamSSORequired[orgID]; ok {
 			if required, ok := teamSSO[teamID]; ok && required {
-				if orgSaml, ok := g.samlIdentities[orgID]; ok {
-					if _, ok := orgSaml[userID]; !ok {
-						logger.WarnContext(ctx, "github user was not added to github group due to group sso requirement",
-							"user", userID,
-							"team", teamID)
-						return nil
-					}
+				saml, err := g.GetGitHubOrgSaml(ctx, orgID)
+				if err != nil {
+					return fmt.Errorf("failed to get saml identity: %w", err)
+				}
+				if _, ok := saml[userID]; ok {
+					logger.WarnContext(ctx, "github user was not added to github group due to group sso requirement",
+						"user", userID,
+						"team", teamID)
+					return nil
 				}
 			}
 		}

--- a/pkg/github/teamreadwriter_test.go
+++ b/pkg/github/teamreadwriter_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-github/v61/github"
+	"github.com/shurcooL/githubv4"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/abcxyz/pkg/testutil"
@@ -748,8 +749,9 @@ func TestTeamReadWriter_GetDescendants(t *testing.T) {
 			defer server.Close()
 
 			client := githubClient(server)
+			gqclient := graphqlClient(server)
 
-			groupRW := NewTeamReadWriter(tc.tokenSource, client, nil, nil)
+			groupRW := NewTeamReadWriter(tc.tokenSource, client, gqclient, nil)
 
 			got, err := groupRW.Descendants(ctx, tc.groupID)
 			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
@@ -828,8 +830,9 @@ func TestTeamReadWriter_GetUser(t *testing.T) {
 			defer server.Close()
 
 			client := githubClient(server)
+			gqclient := graphqlClient(server)
 
-			groupRW := NewTeamReadWriter(tc.tokenSource, client, nil, nil)
+			groupRW := NewTeamReadWriter(tc.tokenSource, client, gqclient, nil)
 
 			got, err := groupRW.GetUser(ctx, tc.userID)
 			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
@@ -2202,6 +2205,11 @@ func githubClient(server *httptest.Server) *github.Client {
 	client := github.NewClient(nil)
 	baseURL, _ := url.Parse(server.URL + "/")
 	client.BaseURL = baseURL
+	return client
+}
+
+func graphqlClient(server *httptest.Server) *githubv4.Client {
+	client := githubv4.NewClient(nil)
 	return client
 }
 

--- a/pkg/github/teamreadwriter_test.go
+++ b/pkg/github/teamreadwriter_test.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-github/v61/github"
-	"github.com/shurcooL/githubv4"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/abcxyz/pkg/testutil"
@@ -124,7 +123,7 @@ func TestTeamReadWriter_GetGroup(t *testing.T) {
 
 			client := githubClient(server)
 
-			groupRW := NewTeamReadWriter(tc.tokenSource, client, nil, nil)
+			groupRW := NewTeamReadWriter(tc.tokenSource, client, DefaultGitHubEndpointURL, nil)
 
 			got, err := groupRW.GetGroup(ctx, tc.groupID)
 			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
@@ -501,7 +500,7 @@ func TestTeamReadWriter_GetMembers(t *testing.T) {
 
 			client := githubClient(server)
 
-			groupRW := NewTeamReadWriter(tc.tokenSource, client, nil, nil, tc.opts...)
+			groupRW := NewTeamReadWriter(tc.tokenSource, client, DefaultGitHubEndpointURL, nil, tc.opts...)
 
 			got, err := groupRW.GetMembers(ctx, tc.groupID)
 			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
@@ -749,9 +748,8 @@ func TestTeamReadWriter_GetDescendants(t *testing.T) {
 			defer server.Close()
 
 			client := githubClient(server)
-			gqclient := graphqlClient(server)
 
-			groupRW := NewTeamReadWriter(tc.tokenSource, client, gqclient, nil)
+			groupRW := NewTeamReadWriter(tc.tokenSource, client, DefaultGitHubEndpointURL, nil)
 
 			got, err := groupRW.Descendants(ctx, tc.groupID)
 			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
@@ -830,9 +828,8 @@ func TestTeamReadWriter_GetUser(t *testing.T) {
 			defer server.Close()
 
 			client := githubClient(server)
-			gqclient := graphqlClient(server)
 
-			groupRW := NewTeamReadWriter(tc.tokenSource, client, gqclient, nil)
+			groupRW := NewTeamReadWriter(tc.tokenSource, client, DefaultGitHubEndpointURL, nil)
 
 			got, err := groupRW.GetUser(ctx, tc.userID)
 			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
@@ -2165,7 +2162,7 @@ func TestTeamReadWriter_SetMembers(t *testing.T) {
 
 			client := githubClient(server)
 
-			groupRW := NewTeamReadWriter(tc.tokenSource, client, nil, nil, tc.opts...)
+			groupRW := NewTeamReadWriter(tc.tokenSource, client, DefaultGitHubEndpointURL, nil, tc.opts...)
 
 			err := groupRW.SetMembers(ctx, tc.groupID, tc.inputMembers)
 			if diff := testutil.DiffErrString(err, tc.wantSetErr); diff != "" {
@@ -2205,11 +2202,6 @@ func githubClient(server *httptest.Server) *github.Client {
 	client := github.NewClient(nil)
 	baseURL, _ := url.Parse(server.URL + "/")
 	client.BaseURL = baseURL
-	return client
-}
-
-func graphqlClient(server *httptest.Server) *githubv4.Client {
-	client := githubv4.NewClient(nil)
 	return client
 }
 


### PR DESCRIPTION
This PR will be helpful for our internal development as internally, teamlink is hosted as a service, we can't only initialize the SAML identity when service started.

Feature contained in this PR includes:
1. Update GitHub's `TeamReadWriter` with a `endpoint` field. This is usefully for creating graphql client to get saml identities.
2. Change `orgSamlIdentities` into a cache. Thus if teamlink is running as a service, saml can be updated.