### PR TITLE
chore: temporarily add temp-lint.yml

### DIFF
--- a/.github/workflows/temp-lint.yml
+++ b/.github/workflows/temp-lint.yml
@@ -1,0 +1,279 @@
+# Copyright 2025 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'lint'
+
+# NOTE: This workflow is NOT intended to be a reusable workflow via
+# workflow_call. Instead it will be "reused" by configuring via organization
+# rulesets as a required workflow. As such, this workflow follows the naming
+# convention for other workflow_call-able workflows in the abcxyz/actions
+# respository.
+on:
+  pull_request:
+  merge_group:
+
+concurrency:
+  group: '${{ github.workflow }}-${{ github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  init:
+    runs-on: 'ubuntu-latest'
+    if: |
+      github.repository != 'abcxyz/actions'
+    outputs:
+      lint-targets: '${{ steps.lint-targets.outputs.lint-targets }}'
+      gomod-dirs: '${{ steps.lint-targets.outputs.gomod-dirs }}'
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
+        with:
+          fetch-depth: 1 # shallow checkout
+          ref: '${{ github.event.pull_request.head.sha }}'
+
+      - name: 'Identify Lint Targets'
+        id: 'lint-targets'
+        env:
+          REF: '${{ github.event.pull_request.head.sha }}'
+          LC_ALL: 'C'
+        shell: 'bash'
+        run: |-
+          # match_files determines if the current git repository has any files
+          # matching the given pattern. This has been performance tested
+          # against a shallow checkout of chromium (future changes should be
+          # tested in the same manner).
+          match_files() {
+            local filepattern="${1}"
+            git ls-tree -r --name-only "${REF}" | grep -m 1 -E "${filepattern}" >/dev/null
+          }
+          find_dirs() {
+            local filepattern="${1}"
+            git ls-tree -r --name-only "${REF}" | grep -E "${filepattern}" | xargs -I {} bash -c 'echo $(dirname {})' | sort || true
+          }
+          to_json() {
+            local filepaths="${1}"
+            echo "${filepaths}" | jq -R -s -c 'split("\n")[:-1]' || true
+          }
+          # Go linting handled separtely from the rest of linting in order to
+          # shard linting across each go.mod file.
+          GOMOD_DIRS="$(find_dirs '(go.mod$)')"
+          if [[ -n "${GOMOD_DIRS}" ]]; then
+            GOMOD_DIRS_JSON="$(to_json "${GOMOD_DIRS}")"
+            echo "::notice::Found go.mod directories: ${GOMOD_DIRS_JSON}"
+            echo "gomod-dirs=${GOMOD_DIRS_JSON}" >> "${GITHUB_OUTPUT}"
+          fi
+          declare -a TARGETS=()
+          if match_files '.*\.(java)$'; then
+            TARGETS+=("java")
+          fi
+          if match_files '.*\.(js)$'; then
+            TARGETS+=("javascript")
+          fi
+          if match_files '.*\.(ts)$'; then
+            TARGETS+=("typescript")
+          fi
+          if match_files '.*\.(sh)$'; then
+            TARGETS+=("shell")
+          fi
+          if match_files '.*\.(tf)$'; then
+            TARGETS+=("terraform")
+          fi
+          if match_files '.*\.(yaml|yml)$'; then
+            TARGETS+=("yaml")
+          fi
+          if match_files '.github/(actions|workflows)/.*\.(yaml|yml)$'; then
+            TARGETS+=("github" "ratchet")
+          fi
+          LINT_TARGETS="$(jq --compact-output --null-input '$ARGS.positional' --args -- "${TARGETS[@]}")"
+          echo "::notice::Found lint targets: ${LINT_TARGETS}"
+          echo "lint-targets=${LINT_TARGETS}" >> "${GITHUB_OUTPUT}"
+
+  lint:
+    runs-on: |-
+      ${{ vars.LINT_RUNS_ON || 'ubuntu-latest' }}
+    needs:
+      - 'init'
+    if: |
+      needs.init.outputs.lint-targets != '[]' && github.repository != 'abcxyz/actions'
+    permissions:
+      contents: 'read'
+    strategy:
+      fail-fast: false
+      max-parallel: 100
+      matrix:
+        lint-target: '${{ fromJSON(needs.init.outputs.lint-targets) }}'
+    env:
+      ##############
+      ## JAVA ######
+      ##############
+      JAVA_LINT_JAVA_VERSION: |-
+        ${{ vars.JAVA_LINT_JAVA_VERSION }}
+      JAVA_LINT_JAVA_DISTRIBUTION: |-
+        ${{ vars.JAVA_LINT_JAVA_VERSION || 'zulu' }}
+      JAVA_LINT_GOOGLE_JAVA_FORMAT_VERSION: |-
+        ${{ vars.JAVA_LINT_GOOGLE_JAVA_FORMAT_VERSION || '1.25.2' }}
+      JAVA_LINT_DIRECTORY: |-
+        ${{ vars.JAVA_LINT_DIRECTORY || '.' }}
+      ##############
+      ## SHELL #####
+      ##############
+      LINT_SHELL_TARGET: |-
+        ${{ vars.LINT_SHELL_TARGET || '.' }}
+      ##############
+      ## TERRAFORM #
+      ##############
+      TERRAFORM_LINT_TERRAFORM_VERSION: |-
+        ${{ vars.TERRAFORM_LINT_TERRAFORM_VERSION }}
+      TERRAFORM_LINT_DIRECTORY: |-
+        ${{ vars.TERRAFORM_LINT_DIRECTORY || '' }}
+      ##############
+      ## YAML ######
+      ##############
+      # The URL to a yamllint config file. This is only used if no file is found in the local directory.
+      YAML_LINT_YAMLLINT_URL: |-
+        ${{ vars.YAML_LINT_YAMLLINT_URL || 'https://raw.githubusercontent.com/abcxyz/actions/main/.yamllint.yml' }}
+      # Version of yamllint linter to use
+      YAML_LINT_YAMLLINT_VERSION: |-
+        ${{ vars.YAML_LINT_YAMLLINT_VERSION || '1.32.0' }}
+      # File or directory containing YAML files to lint.
+      YAML_LINT_TARGET: |-
+        ${{ vars.YAML_LINT_TARGET || '.' }}
+      ##############
+      ## GITHUB ####
+      ##############
+      # Note, must not start with GITHUB_
+      # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#naming-conventions-for-configuration-variables
+      ACTIONS_LINT_ACTIONLINT_VERSION: |-
+        ${{ vars.ACTIONS_LINT_ACTIONLINT_VERSION || '1.7.7' }}
+
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
+        with:
+          fetch-depth: 1 # shallow clone
+
+      - name: '[JAVA] Lint Java'
+        if: |
+          matrix.lint-target == 'java'
+        uses: 'abcxyz/actions/.github/actions/lint-java@main' # ratchet:exclude
+        with:
+          java_version: '${{ env.JAVA_LINT_JAVA_VERSION }}'
+          java_distribution: '${{ env.JAVA_LINT_JAVA_DISTRIBUTION }}'
+          google_java_format_version: '${{ env.JAVA_LINT_GOOGLE_JAVA_FORMAT_VERSION }}'
+          directory: '${{ env.JAVA_LINT_DIRECTORY }}'
+
+      - name: '[JAVASCRIPT] Lint Javascript'
+        if: |
+          matrix.lint-target == 'javascript'
+        run: |-
+          echo "TODO: Lint javascript"
+
+      - name: '[TYPESCRIPT] Lint Typescript'
+        if: |
+          matrix.lint-target == 'typescript'
+        run: |-
+          echo "TODO: Lint typescript"
+
+      - name: '[SHELL] Lint Shell'
+        if: |
+          matrix.lint-target == 'shell'
+        uses: 'abcxyz/actions/.github/actions/lint-shell@main' # ratchet:exclude
+        with:
+          target: '${{ env.LINT_SHELL_TARGET }}'
+
+      - name: '[TERRAFORM] Lint Terraform'
+        if: |
+          matrix.lint-target == 'terraform'
+        uses: 'abcxyz/actions/.github/actions/lint-terraform@main' # ratchet:exclude
+        with:
+          terraform_version: '${{ env.TERRAFORM_LINT_TERRAFORM_VERSION }}'
+          directory: '${{ env.TERRAFORM_LINT_DIRECTORY }}'
+
+      - name: '[YAML] lint yaml'
+        if: |
+          matrix.lint-target == 'yaml'
+        uses: 'abcxyz/actions/.github/actions/lint-yaml@main' # ratchet:exclude
+        with:
+          yamllint_url: '${{ env.YAML_LINT_YAMLLINT_URL }}'
+          yamllint_version: '${{ env.YAML_LINT_YAMLLINT_VERSION }}'
+          target: '${{ env.YAML_LINT_TARGET }}'
+
+      - name: '[GITHUB] lint ratchet'
+        if: |
+          matrix.lint-target == 'ratchet'
+        uses: 'sethvargo/ratchet@db1c14407c5a1cac5ff7b956ce3b6fd8cbafd4ef' # ratchet:sethvargo/ratchet@main
+        with:
+          files: './.github/actions/**/*.yml ./.github/workflows/*.yml'
+
+      - name: '[GITHUB] lint actions'
+        if: |
+          matrix.lint-target == 'github'
+        uses: 'abcxyz/actions/.github/actions/lint-github-actions@main' # ratchet:exclude
+        with:
+          actionlint_version: '${{ env.ACTIONS_LINT_ACTIONLINT_VERSION }}'
+
+  lint-go:
+    runs-on: |-
+      ${{ vars.LINT_RUNS_ON || 'ubuntu-latest' }}
+    needs:
+      - 'init'
+    if: |
+      needs.init.outputs.gomod-dirs != '' && needs.init.outputs.gomod-dirs != '[]' && github.repository != 'abcxyz/actions'
+    permissions:
+      contents: 'read'
+    strategy:
+      fail-fast: false
+      max-parallel: 100
+      matrix:
+        gomod-dir: '${{ fromJSON(needs.init.outputs.gomod-dirs) }}'
+    env:
+      ##############
+      ## GOLANG ####
+      ##############
+      # The version of Go to install and use.
+      GO_LINT_GO_VERSION: |-
+        ${{ vars.GO_LINT_GO_VERSION }}
+      # Path to the go.mod file to extract a version.
+      GO_LINT_GOLANGCI_URL: |-
+        ${{ vars.GO_LINT_GOLANGCI_URL || 'https://raw.githubusercontent.com/abcxyz/actions/main/default.golangci.yml' }}
+      GO_LINT_GOLANGCI_LINT_VERSION: |-
+        ${{ vars.GO_LINT_GOLANGCI_LINT_VERSION || 'v1.64' }}
+
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
+        with:
+          fetch-depth: 1 # shallow clone
+
+      - name: '[GOLANG] Lint Go modules'
+        if: |
+          always()
+        uses: 'abcxyz/actions/.github/actions/lint-go-modules@main' # ratchet:exclude
+        with:
+          go_version: '${{ env.GO_LINT_GO_VERSION }}'
+          go_version_file: '${{ matrix.gomod-dir }}/go.mod'
+          golangci_url: '${{ env.GO_LINT_GOLANGCI_URL }}'
+          directory: '${{ matrix.gomod-dir }}'
+          golangci_lint_version: '${{ env.GO_LINT_GOLANGCI_LINT_VERSION }}'
+
+      - name: '[GOLANG] Lint Go'
+        if: |
+          always()
+        uses: 'abcxyz/actions/.github/actions/lint-go@main' # ratchet:exclude
+        with:
+          go_version: '${{ env.GO_LINT_GO_VERSION }}'
+          go_version_file: '${{ matrix.gomod-dir }}/go.mod'
+          golangci_url: '${{ env.GO_LINT_GOLANGCI_URL }}'
+          directory: '${{ matrix.gomod-dir }}'
+          golangci_lint_version: '${{ env.GO_LINT_GOLANGCI_LINT_VERSION }}'


### PR DESCRIPTION
Temporarily adds the lint.yml from abcxyz/actions, then fixes lint problems, then removes the lint.yml. This repo will be added to the org ruleset so it gets linted after this merges.