### PR TITLE
chore: bump go-github version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.0
 require (
 	github.com/abcxyz/pkg v1.4.0
 	github.com/google/go-cmp v0.6.0
-	github.com/google/go-github/v61 v61.0.0
+	github.com/google/go-github/v67 v67.0.0
 	github.com/shurcooL/githubv4 v0.0.0-20240727222349-48295856cce7
 	gitlab.com/gitlab-org/api/client-go v0.122.0
 	golang.org/x/oauth2 v0.26.0

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-github/v61 v61.0.0 h1:VwQCBwhyE9JclCI+22/7mLB1PuU9eowCXKY5pNlu1go=
-github.com/google/go-github/v61 v61.0.0/go.mod h1:0WR+KmsWX75G2EbpyGsGmradjo3IiciuI4BmdVCobQY=
+github.com/google/go-github/v67 v67.0.0 h1:g11NDAmfaBaCO8qYdI9fsmbaRipHNWRIU/2YGvlh4rg=
+github.com/google/go-github/v67 v67.0.0/go.mod h1:zH3K7BxjFndr9QSeFibx4lTKkYS3K9nDanoI1NjaOtY=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/s2a-go v0.1.9 h1:LGD7gtMgezd8a/Xak7mEWL0PjoTQFvpRudN895yqKW0=

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/go-github/v61/github"
+	"github.com/google/go-github/v67/github"
 	"github.com/shurcooL/githubv4"
 	"golang.org/x/oauth2"
 )

--- a/pkg/github/pagination.go
+++ b/pkg/github/pagination.go
@@ -17,7 +17,7 @@ package github
 import (
 	"fmt"
 
-	"github.com/google/go-github/v61/github"
+	"github.com/google/go-github/v67/github"
 )
 
 // paginate is a helper function that iterates through a series of

--- a/pkg/github/sso.go
+++ b/pkg/github/sso.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/google/go-github/v61/github"
+	"github.com/google/go-github/v67/github"
 	"github.com/shurcooL/githubv4"
 )
 

--- a/pkg/github/teamreadwriter.go
+++ b/pkg/github/teamreadwriter.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/v61/github"
+	"github.com/google/go-github/v67/github"
 	"github.com/shurcooL/githubv4"
 	"google.golang.org/protobuf/proto"
 

--- a/pkg/github/teamreadwriter_test.go
+++ b/pkg/github/teamreadwriter_test.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-github/v61/github"
+	"github.com/google/go-github/v67/github"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/abcxyz/pkg/testutil"


### PR DESCRIPTION
to match what we use internally, also v67 has new feature to manipulate org role which will be needed in the subsequent prs.