### PR TITLE
chore: remove pkg wide variable for testing

### DIFF
--- a/pkg/groupsync/manytomanysyncer_test.go
+++ b/pkg/groupsync/manytomanysyncer_test.go
@@ -23,11 +23,6 @@ import (
 	"github.com/abcxyz/pkg/testutil"
 )
 
-var (
-	errMappedGroupIDNotFound = fmt.Errorf("errMappedGroupIDNotFound")
-	errAllGroupIDs           = fmt.Errorf("errAllGroupIDs")
-)
-
 func TestSync(t *testing.T) {
 	t.Parallel()
 
@@ -315,7 +310,7 @@ func TestSync(t *testing.T) {
 			targetGroupMapper: &testOneToManyGroupMapper{
 				m: targetGroupMapping,
 				mappedGroupIdsErr: map[string]error{
-					"98": errMappedGroupIDNotFound,
+					"98": fmt.Errorf("injected mappedGroupIdsErr"),
 				},
 			},
 			userMapper: &testUserMapper{
@@ -339,7 +334,7 @@ func TestSync(t *testing.T) {
 					&UserMember{Usr: &User{ID: "zw"}},
 				},
 			},
-			wantErr: fmt.Sprintf("error getting associated source group ids: %s", errMappedGroupIDNotFound.Error()),
+			wantErr: fmt.Sprintf("error getting associated source group ids: %s", "injected mappedGroupIdsErr"),
 		},
 		{
 			name:         "error_getting_source_users_partial",
@@ -1019,7 +1014,7 @@ func TestSyncAll(t *testing.T) {
 			sourceGroupClient: &testReadWriteGroupClient{},
 			targetGroupClient: &testReadWriteGroupClient{},
 			sourceGroupMapper: &testOneToManyGroupMapper{
-				allGroupIDsErr: errAllGroupIDs,
+				allGroupIDsErr: fmt.Errorf("injected allGroupIDsErr"),
 			},
 			targetGroupMapper: &testOneToManyGroupMapper{},
 			userMapper:        &testUserMapper{},
@@ -1084,7 +1079,7 @@ func TestSyncAll(t *testing.T) {
 			sourceGroupMapper: &testOneToManyGroupMapper{
 				m: sourceGroupMapping,
 				mappedGroupIdsErr: map[string]error{
-					"1": errMappedGroupIDNotFound,
+					"1": fmt.Errorf("injected mappedGroupIdsErr"),
 				},
 			},
 			targetGroupMapper: &testOneToManyGroupMapper{
@@ -1181,11 +1176,11 @@ func TestSyncAll(t *testing.T) {
 			sourceGroupMapper: &testOneToManyGroupMapper{
 				m: sourceGroupMapping,
 				mappedGroupIdsErr: map[string]error{
-					"1": errMappedGroupIDNotFound,
-					"2": errMappedGroupIDNotFound,
-					"3": errMappedGroupIDNotFound,
-					"4": errMappedGroupIDNotFound,
-					"5": errMappedGroupIDNotFound,
+					"1": fmt.Errorf("injected mappedGroupIdsErr"),
+					"2": fmt.Errorf("injected mappedGroupIdsErr"),
+					"3": fmt.Errorf("injected mappedGroupIdsErr"),
+					"4": fmt.Errorf("injected mappedGroupIdsErr"),
+					"5": fmt.Errorf("injected mappedGroupIdsErr"),
 				},
 			},
 			targetGroupMapper: &testOneToManyGroupMapper{


### PR DESCRIPTION
these error variables are accessible in the groupsync package which could cause confusions since they are only errors used in tests.  We cannot prefix the variables since lint complaints naming should start with "err".