### PR TITLE
feat: add multiple usermapper in manytoone syncer

### DIFF
--- a/pkg/groupsync/groups.go
+++ b/pkg/groupsync/groups.go
@@ -102,6 +102,8 @@ type UserMapper interface {
 type User struct {
 	// ID is the user's ID in the group system.
 	ID string `json:"id,omitempty"`
+	// System is where the user comes from.
+	System string `json:"system,omitempty"`
 	// Attributes represent arbitrary attributes about the user
 	// in the given group system. This field is typically set by
 	// the corresponding GroupReader when retrieving the user.

--- a/pkg/groupsync/manytoonesyncer_test.go
+++ b/pkg/groupsync/manytoonesyncer_test.go
@@ -33,7 +33,7 @@ func TestManyToOneSyncer_Name(t *testing.T) {
 		&testReadWriteGroupClient{},
 		&testOneToOneGroupMapper{},
 		&testOneToManyGroupMapper{},
-		&testUserMapper{},
+		map[string]UserMapper{},
 	)
 
 	res := syncer.Name()
@@ -46,11 +46,13 @@ func TestManyToOneSyncer_Sync(t *testing.T) {
 	t.Parallel()
 
 	// key: source user, value: target user
-	userMapping := map[string]string{
+	userMapping1 := map[string]string{
 		"su1": "tu1",
 		"su2": "tu2",
 		"su3": "tu3",
 		"su4": "tu4",
+	}
+	userMapping2 := map[string]string{
 		"su5": "tu5",
 	}
 
@@ -145,7 +147,7 @@ func TestManyToOneSyncer_Sync(t *testing.T) {
 		targetGroupClient  GroupReadWriter
 		sourceGroupMapper  OneToOneGroupMapper
 		targetGroupMapper  OneToManyGroupMapper
-		userMapper         UserMapper
+		userMappers        map[string]UserMapper
 		syncID             string
 		want               map[string][]Member
 		wantErr            string
@@ -175,8 +177,10 @@ func TestManyToOneSyncer_Sync(t *testing.T) {
 			targetGroupMapper: &testOneToManyGroupMapper{
 				m: targetGroupMapping,
 			},
-			userMapper: &testUserMapper{
-				m: userMapping,
+			userMappers: map[string]UserMapper{
+				sourceSystem1: &testUserMapper{
+					m: userMapping1,
+				},
 			},
 			syncID: "sg1",
 			want: map[string][]Member{
@@ -219,8 +223,13 @@ func TestManyToOneSyncer_Sync(t *testing.T) {
 			targetGroupMapper: &testOneToManyGroupMapper{
 				m: targetGroupMapping,
 			},
-			userMapper: &testUserMapper{
-				m: userMapping,
+			userMappers: map[string]UserMapper{
+				sourceSystem1: &testUserMapper{
+					m: userMapping1,
+				},
+				sourceSystem2: &testUserMapper{
+					m: userMapping2,
+				},
 			},
 			syncID: "sg6",
 			want: map[string][]Member{
@@ -262,8 +271,13 @@ func TestManyToOneSyncer_Sync(t *testing.T) {
 			targetGroupMapper: &testOneToManyGroupMapper{
 				m: targetGroupMapping,
 			},
-			userMapper: &testUserMapper{
-				m: userMapping,
+			userMappers: map[string]UserMapper{
+				sourceSystem1: &testUserMapper{
+					m: userMapping1,
+				},
+				sourceSystem2: &testUserMapper{
+					m: userMapping2,
+				},
 			},
 			syncID: "sg4",
 			want: map[string][]Member{
@@ -284,7 +298,7 @@ func TestManyToOneSyncer_Sync(t *testing.T) {
 			targetGroupClient:  &testReadWriteGroupClient{},
 			sourceGroupMapper:  &testOneToOneGroupMapper{},
 			targetGroupMapper:  &testOneToManyGroupMapper{},
-			userMapper:         &testUserMapper{},
+			userMappers:        map[string]UserMapper{},
 			syncID:             "sg1",
 			wantErr:            "error fetching target group id",
 		},
@@ -316,8 +330,10 @@ func TestManyToOneSyncer_Sync(t *testing.T) {
 					"tg1": fmt.Errorf("injected mappedGroupIdsErr for tg1"),
 				},
 			},
-			userMapper: &testUserMapper{
-				m: userMapping,
+			userMappers: map[string]UserMapper{
+				sourceSystem1: &testUserMapper{
+					m: userMapping1,
+				},
 			},
 			syncID: "sg1",
 			want: map[string][]Member{
@@ -352,8 +368,10 @@ func TestManyToOneSyncer_Sync(t *testing.T) {
 			targetGroupMapper: &testOneToManyGroupMapper{
 				m: targetGroupMapping,
 			},
-			userMapper: &testUserMapper{
-				m: userMapping,
+			userMappers: map[string]UserMapper{
+				sourceSystem1: &testUserMapper{
+					m: userMapping1,
+				},
 			},
 			syncID: "sg4",
 			want: map[string][]Member{
@@ -401,8 +419,13 @@ func TestManyToOneSyncer_Sync(t *testing.T) {
 			targetGroupMapper: &testOneToManyGroupMapper{
 				m: targetGroupMapping,
 			},
-			userMapper: &testUserMapper{
-				m: userMapping,
+			userMappers: map[string]UserMapper{
+				sourceSystem1: &testUserMapper{
+					m: userMapping1,
+				},
+				sourceSystem2: &testUserMapper{
+					m: userMapping2,
+				},
 			},
 			syncID: "sg4",
 			want: map[string][]Member{
@@ -436,8 +459,13 @@ func TestManyToOneSyncer_Sync(t *testing.T) {
 			targetGroupMapper: &testOneToManyGroupMapper{
 				m: targetGroupMapping,
 			},
-			userMapper: &testUserMapper{
-				m: userMapping,
+			userMappers: map[string]UserMapper{
+				sourceSystem1: &testUserMapper{
+					m: userMapping1,
+				},
+				sourceSystem2: &testUserMapper{
+					m: userMapping2,
+				},
 			},
 			syncID: "sg1",
 			want: map[string][]Member{
@@ -472,10 +500,12 @@ func TestManyToOneSyncer_Sync(t *testing.T) {
 			targetGroupMapper: &testOneToManyGroupMapper{
 				m: targetGroupMapping,
 			},
-			userMapper: &testUserMapper{
-				m: userMapping,
-				mappedUserIDErrs: map[string]error{
-					"su1": fmt.Errorf("injected mappedUserIDErrs for su1"),
+			userMappers: map[string]UserMapper{
+				sourceSystem1: &testUserMapper{
+					m: userMapping1,
+					mappedUserIDErrs: map[string]error{
+						"su1": fmt.Errorf("injected mappedUserIDErrs for su1"),
+					},
 				},
 			},
 			syncID: "sg1",
@@ -513,19 +543,14 @@ func TestManyToOneSyncer_Sync(t *testing.T) {
 			targetGroupMapper: &testOneToManyGroupMapper{
 				m: targetGroupMapping,
 			},
-			userMapper: &testUserMapper{
-				mappedUserIDErrs: map[string]error{
-					"su1": fmt.Errorf("injected mappedUserIDErrs"),
-					"su2": fmt.Errorf("injected mappedUserIDErrs"),
-				},
-			},
-			syncID: "sg1",
+			userMappers: map[string]UserMapper{},
+			syncID:      "sg5", // Mapped to both source systems.
 			want: map[string][]Member{
 				"tg1": {},
 				"tg2": {},
 				"tg3": {},
 			},
-			wantErr: "injected mappedUserIDErrs",
+			wantErr: "user mapper not found",
 		},
 		{
 			name: "error_setting_members",
@@ -555,8 +580,10 @@ func TestManyToOneSyncer_Sync(t *testing.T) {
 			targetGroupMapper: &testOneToManyGroupMapper{
 				m: targetGroupMapping,
 			},
-			userMapper: &testUserMapper{
-				m: userMapping,
+			userMappers: map[string]UserMapper{
+				sourceSystem1: &testUserMapper{
+					m: userMapping1,
+				},
 			},
 			syncID: "sg1",
 			want: map[string][]Member{
@@ -581,7 +608,7 @@ func TestManyToOneSyncer_Sync(t *testing.T) {
 				tc.targetGroupClient,
 				tc.sourceGroupMapper,
 				tc.targetGroupMapper,
-				tc.userMapper,
+				tc.userMappers,
 			)
 
 			err := syncer.Sync(ctx, tc.syncID)
@@ -605,12 +632,13 @@ func TestManyToOneSyncer_Sync(t *testing.T) {
 func TestManyToOneSyncer_SyncAll(t *testing.T) {
 	t.Parallel()
 
-	// key: source user, value: target user
-	userMapping := map[string]string{
+	userMapping1 := map[string]string{
 		"su1": "tu1",
 		"su2": "tu2",
 		"su3": "tu3",
 		"su4": "tu4",
+	}
+	userMapping2 := map[string]string{
 		"su5": "tu5",
 	}
 
@@ -698,13 +726,12 @@ func TestManyToOneSyncer_SyncAll(t *testing.T) {
 		targetGroupClient  GroupReadWriter
 		sourceGroupMapper  OneToOneGroupMapper
 		targetGroupMapper  OneToManyGroupMapper
-		userMapper         UserMapper
+		userMappers        map[string]UserMapper
 		want               map[string][]Member
 		wantErr            string
 	}{
 		{
 			name: "sync_all_success",
-
 			sourceGroupClients: map[string]GroupReader{
 				sourceSystem1: &testReadWriteGroupClient{
 					groups:       sourceGroups1,
@@ -733,8 +760,13 @@ func TestManyToOneSyncer_SyncAll(t *testing.T) {
 			targetGroupMapper: &testOneToManyGroupMapper{
 				m: targetGroupMapping,
 			},
-			userMapper: &testUserMapper{
-				m: userMapping,
+			userMappers: map[string]UserMapper{
+				sourceSystem1: &testUserMapper{
+					m: userMapping1,
+				},
+				sourceSystem2: &testUserMapper{
+					m: userMapping2,
+				},
 			},
 			want: map[string][]Member{
 				"tg1": {
@@ -763,7 +795,7 @@ func TestManyToOneSyncer_SyncAll(t *testing.T) {
 				allGroupIDsErr: fmt.Errorf("injected allGroupIDsErr"),
 			},
 			targetGroupMapper: &testOneToManyGroupMapper{},
-			userMapper:        &testUserMapper{},
+			userMappers:       map[string]UserMapper{},
 			wantErr:           "injected allGroupIDsErr",
 		},
 		{
@@ -799,8 +831,13 @@ func TestManyToOneSyncer_SyncAll(t *testing.T) {
 			targetGroupMapper: &testOneToManyGroupMapper{
 				m: targetGroupMapping,
 			},
-			userMapper: &testUserMapper{
-				m: userMapping,
+			userMappers: map[string]UserMapper{
+				sourceSystem1: &testUserMapper{
+					m: userMapping1,
+				},
+				sourceSystem2: &testUserMapper{
+					m: userMapping2,
+				},
 			},
 			want: map[string][]Member{
 				"tg1": {},
@@ -856,8 +893,13 @@ func TestManyToOneSyncer_SyncAll(t *testing.T) {
 			targetGroupMapper: &testOneToManyGroupMapper{
 				m: targetGroupMapping,
 			},
-			userMapper: &testUserMapper{
-				m: userMapping,
+			userMappers: map[string]UserMapper{
+				sourceSystem1: &testUserMapper{
+					m: userMapping1,
+				},
+				sourceSystem2: &testUserMapper{
+					m: userMapping2,
+				},
 			},
 			want: map[string][]Member{
 				"tg1": {},
@@ -881,7 +923,7 @@ func TestManyToOneSyncer_SyncAll(t *testing.T) {
 				tc.targetGroupClient,
 				tc.sourceGroupMapper,
 				tc.targetGroupMapper,
-				tc.userMapper,
+				tc.userMappers,
 			)
 
 			err := syncer.SyncAll(ctx)


### PR DESCRIPTION
Since there are multiple source systems, there could be multiple user mapper, we cannot use one user mapper, since we cannot pass the user source system to the user mapper without changing its interface (UserMapper.MappedUserID(ctx context.Context, userID string)). 

In order to know which user mapper to use, we need to pass the group/user system. This PR pass the info via the new `System` field in the user.

The other option is to pass the value in the [mapping metadata](https://github.com/abcxyz/team-link/blob/main/pkg/groupsync/groups.go#L111), but the ManyToOneSyncer should stay agnostic of the mapping metadata being passed from upstream since it is a struct with many interfaces as fields and act as a middle man between the source and target systems.