### PR TITLE
fix: Update Go module references to include v2 path

### DIFF
--- a/cmd/tlctl/main.go
+++ b/cmd/tlctl/main.go
@@ -21,7 +21,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/abcxyz/team-link/pkg/cli"
+	"github.com/abcxyz/team-link/v2/pkg/cli"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/abcxyz/team-link
+module github.com/abcxyz/team-link/v2
 
 go 1.24
 

--- a/pkg/cli/sync.go
+++ b/pkg/cli/sync.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	"github.com/abcxyz/pkg/cli"
-	"github.com/abcxyz/team-link/pkg/common"
+	"github.com/abcxyz/team-link/v2/pkg/common"
 )
 
 var _ cli.Command = (*SyncCommand)(nil)

--- a/pkg/common/googlegroup_github/mapper.go
+++ b/pkg/common/googlegroup_github/mapper.go
@@ -22,9 +22,9 @@ import (
 	"strings"
 
 	"github.com/abcxyz/pkg/logging"
-	api "github.com/abcxyz/team-link/apis/v1alpha3/proto"
-	"github.com/abcxyz/team-link/pkg/github"
-	"github.com/abcxyz/team-link/pkg/groupsync"
+	api "github.com/abcxyz/team-link/v2/apis/v1alpha3/proto"
+	"github.com/abcxyz/team-link/v2/pkg/github"
+	"github.com/abcxyz/team-link/v2/pkg/groupsync"
 )
 
 // GroupMapper implements groupsync.OneToManyGroupMapper

--- a/pkg/common/googlegroup_github/mapper_test.go
+++ b/pkg/common/googlegroup_github/mapper_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	api "github.com/abcxyz/team-link/apis/v1alpha3/proto"
+	api "github.com/abcxyz/team-link/v2/apis/v1alpha3/proto"
 )
 
 func TestCreateBidirectionalGroupMapper(t *testing.T) {

--- a/pkg/common/group.go
+++ b/pkg/common/group.go
@@ -17,10 +17,10 @@ package common
 import (
 	"fmt"
 
-	api "github.com/abcxyz/team-link/apis/v1alpha3/proto"
-	tltypes "github.com/abcxyz/team-link/internal"
-	googlegroupgithub "github.com/abcxyz/team-link/pkg/common/googlegroup_github"
-	"github.com/abcxyz/team-link/pkg/groupsync"
+	api "github.com/abcxyz/team-link/v2/apis/v1alpha3/proto"
+	tltypes "github.com/abcxyz/team-link/v2/internal"
+	googlegroupgithub "github.com/abcxyz/team-link/v2/pkg/common/googlegroup_github"
+	"github.com/abcxyz/team-link/v2/pkg/groupsync"
 )
 
 // NewBidirectionalOneToManyGroupMapper creates two OneToManyGroupMapper, directions are src->target and target->src.

--- a/pkg/common/reader.go
+++ b/pkg/common/reader.go
@@ -18,10 +18,10 @@ import (
 	"context"
 	"fmt"
 
-	api "github.com/abcxyz/team-link/apis/v1alpha3/proto"
-	tltypes "github.com/abcxyz/team-link/internal"
-	"github.com/abcxyz/team-link/pkg/googlegroups"
-	"github.com/abcxyz/team-link/pkg/groupsync"
+	api "github.com/abcxyz/team-link/v2/apis/v1alpha3/proto"
+	tltypes "github.com/abcxyz/team-link/v2/internal"
+	"github.com/abcxyz/team-link/v2/pkg/googlegroups"
+	"github.com/abcxyz/team-link/v2/pkg/groupsync"
 )
 
 // NewReader creates a GroupReader base on source type and input config.

--- a/pkg/common/sync.go
+++ b/pkg/common/sync.go
@@ -19,8 +19,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/abcxyz/team-link/pkg/groupsync"
-	"github.com/abcxyz/team-link/pkg/utils"
+	"github.com/abcxyz/team-link/v2/pkg/groupsync"
+	"github.com/abcxyz/team-link/v2/pkg/utils"
 )
 
 // Sync syncs membership informations.

--- a/pkg/common/user.go
+++ b/pkg/common/user.go
@@ -18,10 +18,10 @@ import (
 	"context"
 	"fmt"
 
-	api "github.com/abcxyz/team-link/apis/v1alpha3/proto"
-	tltypes "github.com/abcxyz/team-link/internal"
-	gggh "github.com/abcxyz/team-link/pkg/common/googlegroup_github"
-	"github.com/abcxyz/team-link/pkg/groupsync"
+	api "github.com/abcxyz/team-link/v2/apis/v1alpha3/proto"
+	tltypes "github.com/abcxyz/team-link/v2/internal"
+	gggh "github.com/abcxyz/team-link/v2/pkg/common/googlegroup_github"
+	"github.com/abcxyz/team-link/v2/pkg/groupsync"
 )
 
 // NewUserMapper creates a new UserMapper base on source and target system type.

--- a/pkg/common/writer.go
+++ b/pkg/common/writer.go
@@ -18,10 +18,10 @@ import (
 	"context"
 	"fmt"
 
-	api "github.com/abcxyz/team-link/apis/v1alpha3/proto"
-	tltypes "github.com/abcxyz/team-link/internal"
-	"github.com/abcxyz/team-link/pkg/github"
-	"github.com/abcxyz/team-link/pkg/groupsync"
+	api "github.com/abcxyz/team-link/v2/apis/v1alpha3/proto"
+	tltypes "github.com/abcxyz/team-link/v2/internal"
+	"github.com/abcxyz/team-link/v2/pkg/github"
+	"github.com/abcxyz/team-link/v2/pkg/groupsync"
 )
 
 // NewReadWriter creates a new ReadWriter base on target system type and provided config.

--- a/pkg/common/writer_test.go
+++ b/pkg/common/writer_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	api "github.com/abcxyz/team-link/apis/v1alpha3/proto"
+	api "github.com/abcxyz/team-link/v2/apis/v1alpha3/proto"
 )
 
 func TestComputeOrgTeamSSORequired(t *testing.T) {

--- a/pkg/github/enterpriseuserwriter.go
+++ b/pkg/github/enterpriseuserwriter.go
@@ -23,7 +23,7 @@ import (
 	"github.com/google/go-github/v67/github"
 
 	"github.com/abcxyz/pkg/logging"
-	"github.com/abcxyz/team-link/pkg/groupsync"
+	"github.com/abcxyz/team-link/v2/pkg/groupsync"
 )
 
 const defaultMaxUsersToProvision = 1000

--- a/pkg/github/enterpriseuserwriter_test.go
+++ b/pkg/github/enterpriseuserwriter_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/google/go-github/v67/github"
 
 	"github.com/abcxyz/pkg/testutil"
-	"github.com/abcxyz/team-link/pkg/groupsync"
+	"github.com/abcxyz/team-link/v2/pkg/groupsync"
 )
 
 func TestEnterpriseUserWriter_SetMembers(t *testing.T) {

--- a/pkg/github/metadata.go
+++ b/pkg/github/metadata.go
@@ -17,7 +17,7 @@ package github
 import (
 	"slices"
 
-	"github.com/abcxyz/team-link/pkg/groupsync"
+	"github.com/abcxyz/team-link/v2/pkg/groupsync"
 )
 
 type Role string

--- a/pkg/github/orgmembershipreadwriter.go
+++ b/pkg/github/orgmembershipreadwriter.go
@@ -27,8 +27,8 @@ import (
 	"github.com/abcxyz/pkg/cache"
 	"github.com/abcxyz/pkg/logging"
 	"github.com/abcxyz/pkg/sets"
-	"github.com/abcxyz/team-link/pkg/groupsync"
-	"github.com/abcxyz/team-link/pkg/utils"
+	"github.com/abcxyz/team-link/v2/pkg/groupsync"
+	"github.com/abcxyz/team-link/v2/pkg/utils"
 )
 
 // OrgMembershipReadWriter adheres to the groupsync.GroupReadWriter interface

--- a/pkg/github/orgmembershipreadwriter_test.go
+++ b/pkg/github/orgmembershipreadwriter_test.go
@@ -24,7 +24,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/abcxyz/pkg/testutil"
-	"github.com/abcxyz/team-link/pkg/groupsync"
+	"github.com/abcxyz/team-link/v2/pkg/groupsync"
 )
 
 func TestOrgMembershipReadWriter_GetGroup(t *testing.T) {

--- a/pkg/github/teamreadwriter.go
+++ b/pkg/github/teamreadwriter.go
@@ -29,8 +29,8 @@ import (
 	"github.com/abcxyz/pkg/cache"
 	"github.com/abcxyz/pkg/logging"
 	"github.com/abcxyz/pkg/sets"
-	"github.com/abcxyz/team-link/pkg/groupsync"
-	"github.com/abcxyz/team-link/pkg/utils"
+	"github.com/abcxyz/team-link/v2/pkg/groupsync"
+	"github.com/abcxyz/team-link/v2/pkg/utils"
 )
 
 const (

--- a/pkg/github/teamreadwriter_test.go
+++ b/pkg/github/teamreadwriter_test.go
@@ -24,7 +24,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/abcxyz/pkg/testutil"
-	"github.com/abcxyz/team-link/pkg/groupsync"
+	"github.com/abcxyz/team-link/v2/pkg/groupsync"
 )
 
 func TestTeamReadWriter_GetGroup(t *testing.T) {

--- a/pkg/github/testutil.go
+++ b/pkg/github/testutil.go
@@ -28,7 +28,7 @@ import (
 	"github.com/google/go-github/v67/github"
 	"google.golang.org/protobuf/proto"
 
-	"github.com/abcxyz/team-link/pkg/groupsync"
+	"github.com/abcxyz/team-link/v2/pkg/groupsync"
 )
 
 type fakeTokenSource struct {

--- a/pkg/github/tokensource.go
+++ b/pkg/github/tokensource.go
@@ -22,7 +22,7 @@ import (
 	"strconv"
 
 	"github.com/abcxyz/pkg/githubauth"
-	"github.com/abcxyz/team-link/pkg/credentials"
+	"github.com/abcxyz/team-link/v2/pkg/credentials"
 )
 
 // DefaultStaticTokenEnvVar is where we read default github token from.

--- a/pkg/gitlab/access_level.go
+++ b/pkg/gitlab/access_level.go
@@ -17,7 +17,7 @@ package gitlab
 import (
 	gitlab "gitlab.com/gitlab-org/api/client-go"
 
-	"github.com/abcxyz/team-link/pkg/groupsync"
+	"github.com/abcxyz/team-link/v2/pkg/groupsync"
 )
 
 // AccessLevelMetadata holds an access level for a GitLab user being added to

--- a/pkg/gitlab/client.go
+++ b/pkg/gitlab/client.go
@@ -21,7 +21,7 @@ import (
 
 	gitlab "gitlab.com/gitlab-org/api/client-go"
 
-	"github.com/abcxyz/team-link/pkg/credentials"
+	"github.com/abcxyz/team-link/v2/pkg/credentials"
 )
 
 // ClientProvider provides a GitLab client.

--- a/pkg/gitlab/groupreadwriter.go
+++ b/pkg/gitlab/groupreadwriter.go
@@ -28,8 +28,8 @@ import (
 	"github.com/abcxyz/pkg/cache"
 	"github.com/abcxyz/pkg/logging"
 	"github.com/abcxyz/pkg/sets"
-	"github.com/abcxyz/team-link/pkg/groupsync"
-	"github.com/abcxyz/team-link/pkg/utils"
+	"github.com/abcxyz/team-link/v2/pkg/groupsync"
+	"github.com/abcxyz/team-link/v2/pkg/utils"
 )
 
 const (

--- a/pkg/gitlab/groupreadwriter_test.go
+++ b/pkg/gitlab/groupreadwriter_test.go
@@ -29,7 +29,7 @@ import (
 	gitlab "gitlab.com/gitlab-org/api/client-go"
 
 	"github.com/abcxyz/pkg/testutil"
-	"github.com/abcxyz/team-link/pkg/groupsync"
+	"github.com/abcxyz/team-link/v2/pkg/groupsync"
 )
 
 func TestGroupReadWriter_GetGroup(t *testing.T) {

--- a/pkg/googlegroups/client.go
+++ b/pkg/googlegroups/client.go
@@ -21,7 +21,7 @@ import (
 	admin "google.golang.org/api/admin/directory/v1"
 	"google.golang.org/api/cloudidentity/v1"
 
-	"github.com/abcxyz/team-link/pkg/groupsync"
+	"github.com/abcxyz/team-link/v2/pkg/groupsync"
 )
 
 // NewGroupReaderWithDefaultApplicationToken creates a reader for GoogleGroups.

--- a/pkg/googlegroups/groupreader.go
+++ b/pkg/googlegroups/groupreader.go
@@ -23,7 +23,7 @@ import (
 	"google.golang.org/api/cloudidentity/v1"
 
 	"github.com/abcxyz/pkg/logging"
-	"github.com/abcxyz/team-link/pkg/groupsync"
+	"github.com/abcxyz/team-link/v2/pkg/groupsync"
 )
 
 const (

--- a/pkg/groupsync/util.go
+++ b/pkg/groupsync/util.go
@@ -21,7 +21,7 @@ import (
 	"runtime"
 	"sync"
 
-	"github.com/abcxyz/team-link/apis/v1alpha3"
+	"github.com/abcxyz/team-link/v2/apis/v1alpha3"
 )
 
 // ConcurrentSync syncs the given source groups concurrently using the given syncer.

--- a/pkg/utils/textproto.go
+++ b/pkg/utils/textproto.go
@@ -22,8 +22,8 @@ import (
 
 	"google.golang.org/protobuf/encoding/prototext"
 
-	api "github.com/abcxyz/team-link/apis/v1alpha3/proto"
-	tltypes "github.com/abcxyz/team-link/internal"
+	api "github.com/abcxyz/team-link/v2/apis/v1alpha3/proto"
+	tltypes "github.com/abcxyz/team-link/v2/internal"
 )
 
 // ParseMappingTextProto parses a textproto file to TeamLinkMappings type.

--- a/pkg/utils/textproto_test.go
+++ b/pkg/utils/textproto_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/abcxyz/pkg/testutil"
-	api "github.com/abcxyz/team-link/apis/v1alpha3/proto"
+	api "github.com/abcxyz/team-link/v2/apis/v1alpha3/proto"
 )
 
 func TestParseMappingTextProto(t *testing.T) {


### PR DESCRIPTION
This is required for the Go module tooling to recognize the new version.