### PR TITLE
fix: Use MappedUser() instead of MappedUserID() in the ManyToX syncers

### DIFF
--- a/pkg/groupsync/manytomanysyncer.go
+++ b/pkg/groupsync/manytomanysyncer.go
@@ -228,7 +228,7 @@ func (f *ManyToManySyncer) targetUsers(ctx context.Context, sourceUsers []*User)
 	var merr error
 	targetUsers := make([]*User, 0, len(sourceUsers))
 	for _, sourceUser := range sourceUsers {
-		targetUserID, err := f.userMapper.MappedUserID(ctx, sourceUser.ID)
+		targetUser, err := f.userMapper.MappedUser(ctx, sourceUser)
 		if errors.Is(err, ErrTargetUserIDNotFound) {
 			// if there is no mapping for the target user we will just skip them.
 			continue
@@ -237,7 +237,7 @@ func (f *ManyToManySyncer) targetUsers(ctx context.Context, sourceUsers []*User)
 			merr = fmt.Errorf("error mapping source user id %s to target user id: %w", sourceUser.ID, err)
 			continue
 		}
-		targetUsers = append(targetUsers, &User{ID: targetUserID, Metadata: sourceUser.Metadata})
+		targetUsers = append(targetUsers, targetUser)
 	}
 	return targetUsers, merr
 }

--- a/pkg/groupsync/manytoonesyncer.go
+++ b/pkg/groupsync/manytoonesyncer.go
@@ -248,7 +248,7 @@ func (f *ManyToOneSyncer) targetUsers(ctx context.Context, sourceUsers []*User) 
 			merr = errors.Join(merr, fmt.Errorf("user mapper not found for system %s, source user id %s", sourceUser.System, sourceUser.ID))
 			continue
 		}
-		targetUserID, err := userMapper.MappedUserID(ctx, sourceUser.ID)
+		targetUser, err := userMapper.MappedUser(ctx, sourceUser)
 		if errors.Is(err, ErrTargetUserIDNotFound) {
 			// if there is no mapping for the target user we will just skip them.
 			continue
@@ -257,7 +257,7 @@ func (f *ManyToOneSyncer) targetUsers(ctx context.Context, sourceUsers []*User) 
 			merr = errors.Join(merr, fmt.Errorf("error mapping source user id %s to target user id: %w", sourceUser.ID, err))
 			continue
 		}
-		targetUsers = append(targetUsers, &User{ID: targetUserID, Metadata: sourceUser.Metadata})
+		targetUsers = append(targetUsers, targetUser)
 	}
 	return targetUsers, merr
 }


### PR DESCRIPTION
The syncer should be unopinionated on all aspects of how the mapping is done. If the mapper wants to persist the source metadata, convert the metadata from one format to another, or remove it entirely that is OK.

This aligns with the existing behavior for the OneToOne syncer.