### PR TITLE
feat: Skip target group syncing if user set is empty

### DIFF
--- a/pkg/groupsync/manytomanysyncer.go
+++ b/pkg/groupsync/manytomanysyncer.go
@@ -137,6 +137,13 @@ func (f *ManyToManySyncer) Sync(ctx context.Context, sourceGroupID string) error
 			"source_user_ids", sourceUserIds,
 		)
 
+		if len(sourceUserIds) == 0 {
+			logger.WarnContext(ctx, "no source group descendants found. "+
+				"skipping sync in case this is an upstream data issue.",
+				"target_group_id", targetGroupID)
+			continue
+		}
+
 		// map each source user to their corresponding target user
 		targetUsers, err := f.targetUsers(ctx, sourceUsers)
 		targetUserIds := userIDs(targetUsers)

--- a/pkg/groupsync/manytoonesyncer.go
+++ b/pkg/groupsync/manytoonesyncer.go
@@ -143,6 +143,13 @@ func (f *ManyToOneSyncer) sync(ctx context.Context, targetGroupID string) error 
 		"source_user_ids", sourceUserIds,
 	)
 
+	if len(sourceUserIds) == 0 {
+		logger.WarnContext(ctx, "no source group descendants found. "+
+			"skipping sync in case this is an upstream data issue.",
+			"target_group_id", targetGroupID)
+		return merr
+	}
+
 	// Map each source user to their corresponding target user
 	targetUsers, err := f.targetUsers(ctx, sourceUsers)
 	targetUserIds := userIDs(targetUsers)

--- a/pkg/groupsync/manytoonesyncer_test.go
+++ b/pkg/groupsync/manytoonesyncer_test.go
@@ -193,7 +193,7 @@ func TestManyToOneSyncer_Sync(t *testing.T) {
 			},
 		},
 		{
-			name: "empty_group",
+			name: "empty_group_does_not_sync",
 			sourceGroupClients: map[string]GroupReader{
 				sourceSystem1: &testReadWriteGroupClient{
 					groups:       sourceGroups1,
@@ -238,7 +238,7 @@ func TestManyToOneSyncer_Sync(t *testing.T) {
 				},
 				"tg2": {},
 				"tg3": {},
-				"tg4": {},
+				"tg4": {&UserMember{Usr: &User{ID: "tu5"}}},
 			},
 		},
 		{

--- a/pkg/groupsync/onetoonesyncer.go
+++ b/pkg/groupsync/onetoonesyncer.go
@@ -109,6 +109,13 @@ func (f *OneToOneSyncer) Sync(ctx context.Context, sourceGroupID string) error {
 		"source_user_ids", sourceUserIds,
 	)
 
+	if len(sourceUserIds) == 0 {
+		logger.WarnContext(ctx, "no source group descendants found. skipping sync in case this is an upstream data issue.",
+			"source_group_id", sourceGroupID,
+			"target_group_id", targetGroupID)
+		return nil
+	}
+
 	// Map each source user to their corresponding target user
 	targetUsers, err := f.targetUsers(ctx, sourceUsers)
 	targetUserIds := userIDs(targetUsers)


### PR DESCRIPTION
Due to upstream data issues, sometimes group reads can erroneously return empty results. Recently this caused our enterprise members group to appear empty and teamlink removed all users from the enterprise. As a temporary fix until we can get more reliable upstream data, this PR skips syncing an empty set of users to a target group and logs a warning. 