### PR TITLE
fix: user deactivation sanity check

### DIFF
--- a/pkg/github/enterpriseuserwriter_test.go
+++ b/pkg/github/enterpriseuserwriter_test.go
@@ -16,7 +16,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -481,8 +480,8 @@ func TestEnterpriseUserWriter_SetMembers(t *testing.T) {
 			}
 
 			if tc.failUserDeactivationSanityCheck {
-				opts = append(opts, WithUserDeactivationSanityCheck(func(context.Context, *SCIMUser, string) error {
-					return fmt.Errorf("sanity check failed")
+				opts = append(opts, WithUserDeactivationSanityCheck(func(context.Context, *SCIMUser, string) (bool, error) {
+					return false, nil
 				}))
 			}
 


### PR DESCRIPTION
current sanity checks gets a nil user, pass the actual user to perform sanity check on including the target enterprise (will be used to get the mapped source groups)